### PR TITLE
Docstrings for API

### DIFF
--- a/bluesky_queueserver_api/_defaults.py
+++ b/bluesky_queueserver_api/_defaults.py
@@ -1,5 +1,8 @@
 default_allow_request_fail_exceptions = True
 
+default_status_expiration_period = 0.5  # s
+default_status_polling_period = 1.0  # s
+
 default_zmq_request_timeout_recv = 2.0  # s
 default_zmq_request_timeout_send = 0.5  # s
 

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -5,7 +5,16 @@ import time as ttime
 from .api_base import API_Base, WaitMonitor
 from ._defaults import default_wait_timeout
 
-from .api_docstrings import _doc_api_status, _doc_api_wait_for_idle, _doc_api_item_add
+from .api_docstrings import (
+    _doc_api_status,
+    _doc_api_wait_for_idle,
+    _doc_api_item_add,
+    _doc_api_item_get,
+    _doc_api_queue_start,
+    _doc_api_environment_open,
+    _doc_api_environment_close,
+    _doc_api_environment_destroy,
+)
 
 
 class API_Async_Mixin(API_Base):
@@ -242,6 +251,7 @@ class API_Async_Mixin(API_Base):
     #                 API for monitoring and control of Queue
 
     async def item_add(self, item, *, pos=None, before_uid=None, after_uid=None):
+        # Docstring is maintained separately
         request_params = self._prepare_item_add(item=item, pos=pos, before_uid=before_uid, after_uid=after_uid)
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_add", params=request_params)
@@ -270,3 +280,8 @@ class API_Async_Mixin(API_Base):
 API_Async_Mixin.status.__doc__ = _doc_api_status
 API_Async_Mixin.wait_for_idle.__doc__ = _doc_api_wait_for_idle
 API_Async_Mixin.item_add.__doc__ = _doc_api_item_add
+API_Async_Mixin.item_get.__doc__ = _doc_api_item_get
+API_Async_Mixin.queue_start.__doc__ = _doc_api_queue_start
+API_Async_Mixin.environment_open.__doc__ = _doc_api_environment_open
+API_Async_Mixin.environment_close.__doc__ = _doc_api_environment_close
+API_Async_Mixin.environment_destroy.__doc__ = _doc_api_environment_destroy

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -5,12 +5,14 @@ import time as ttime
 from .api_base import API_Base, WaitMonitor
 from ._defaults import default_wait_timeout
 
-from .api_docstrings import _doc_api_status
+from .api_docstrings import _doc_api_status, _doc_api_wait_for_idle, _doc_api_item_add
 
 
 class API_Async_Mixin(API_Base):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, *, status_expiration_period, status_polling_period):
+        super().__init__(
+            status_expiration_period=status_expiration_period, status_polling_period=status_polling_period
+        )
 
         self._is_closing = False
 
@@ -48,7 +50,7 @@ class API_Async_Mixin(API_Base):
                 else:
                     dt = None
 
-                if (dt is None) or (dt > self._status_min_period):
+                if (dt is None) or (dt > self._status_expiration_period):
                     status, raised_exception = None, None
                     try:
                         status = await self._load_status()
@@ -127,7 +129,7 @@ class API_Async_Mixin(API_Base):
 
         monitor = monitor or WaitMonitor()
         monitor._time_start = t_started
-        monitor.set_timeout_period(timeout)
+        monitor.set_timeout(timeout)
 
         event = asyncio.Event()
 
@@ -136,7 +138,7 @@ class API_Async_Mixin(API_Base):
             result = condition(status) if status else False
             monitor._time_elapsed = ttime.time() - monitor.time_start
 
-            if not result and (monitor.time_elapsed > monitor.timeout_period):
+            if not result and (monitor.time_elapsed > monitor.timeout):
                 timeout_occurred = True
                 result = True
             elif monitor.is_cancelled:
@@ -224,33 +226,12 @@ class API_Async_Mixin(API_Base):
     #                 API for monitoring and control of RE Manager
 
     async def status(self, *, reload=False):
-        """
-        Load status of RE Manager. The function returns status or raises exception if
-        operation failed (e.g. timeout occurred).
-
-        Parameters
-        ----------
-        reload: boolean
-            Immediately reload status (``True``) or return cached status if it
-            is not expired (``False``).
-
-        Returns
-        -------
-        dict
-            Copy of the dictionary with RE Manager status.
-
-        Raises
-        ------
-            Reraises the exceptions raised by ``send_request`` API.
-        """
+        # Docstring is maintained separately
         status = await self._status(reload=reload)
         return copy.deepcopy(status)  # Returns copy
 
     async def wait_for_idle(self, *, timeout=default_wait_timeout, monitor=None):
-        """
-        The function raises ``WaitTimeoutError`` if timeout occurs or
-        ``WaitCancelError`` if wait operation was cancelled by ``monitor.cancel()``.
-        """
+        # Docstring is maintained separately
 
         def condition(status):
             return status["manager_state"] == "idle"
@@ -287,3 +268,5 @@ class API_Async_Mixin(API_Base):
 
 
 API_Async_Mixin.status.__doc__ = _doc_api_status
+API_Async_Mixin.wait_for_idle.__doc__ = _doc_api_wait_for_idle
+API_Async_Mixin.item_add.__doc__ = _doc_api_item_add

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -120,6 +120,118 @@ _doc_BInst = _doc_BPlan_BInst_BFunc_common.replace("--ITEM--", "an instruction")
 _doc_BFunc = _doc_BPlan_BInst_BFunc_common.replace("--ITEM--", "a function").replace("--ITEMS--", "functions")
 
 
+_doc_REManagerAPI_ZMQ = """
+    API for communication with RE Manager using 0MQ protocol.
+
+    Parameters
+    ----------
+    zmq_server_address: str or None
+        Address of control 0MQ socket of RE Manager. If ``None``,
+        then the default address ``"tcp://localhost:60615"`` is used.
+    timeout_recv: float
+        ``recv`` timeout for 0MQ socket. Default value is 2.0 seconds.
+    timeout_send: float
+        ``send`` timeout for 0MQ socket. Default value is 0.5 seconds.
+    server_public_key: str or None
+        Public key of RE Manager if the encryption is enabled. Set to ``None``
+        if encryption is not enabled
+    request_fail_exceptions: boolean
+        If ``True`` (default) then API functions that communicate with
+        RE Manager are raising the ``RequestFailError`` exception if
+        the request is rejected (the response contains ``"success": False``,
+        e.g. if a submitted plan is rejected). If ``False``, then API
+        functions are always returning the response and user code is
+        responsible for checking and processing the ``success`` flag.
+    status_expiration_period: float
+        Expiration period for cached RE Manager status,
+        default value: 0.5 seconds
+    status_polling_period: float
+        Polling period for RE Manager status used by 'wait' operations,
+        default value: 1 second
+    loop: asyncio.Loop
+        ``asyncio`` event loop (use only with Async version of the API).
+
+    Examples
+    --------
+
+    Synchronous API:
+
+    .. code-block:: python
+
+        from bluesky_queueserver_api.zmq import REManagerAPI
+        RM = REManagerAPI()
+        # < some useful code >
+        RE.close()
+
+    Asynchronous API:
+
+    .. code-block:: python
+
+        from bluesky_queueserver_api.zmq.aio import REManagerAPI
+
+        async def testing():
+            RM = REManagerAPI()
+            # < some useful code >
+            await RE.close()
+
+        asyncio.run(testing())
+"""
+
+_doc_REManagerAPI_HTTP = """
+    API for communication with RE Manager using HTTP (RESTful API) protocol.
+
+    Parameters
+    ----------
+    http_server_uri: str or None
+        URI of Bluesky HTTP Server. If ``None``, then the default URI
+        `"http://localhost:60610"`` is used.
+    timeout: float
+        Request timeout. Default value is 5.0 seconds.
+    request_fail_exceptions: boolean
+        If ``True`` (default) then API functions that communicate with
+        RE Manager are raising the ``RequestFailError`` exception if
+        the request is rejected (the response contains ``"success": False``,
+        e.g. if a submitted plan is rejected). If ``False``, then API
+        functions are always returning the response and user code is
+        responsible for checking and processing the ``success`` flag.
+    status_expiration_period: float
+        Expiration period for cached RE Manager status,
+        default value: 0.5 seconds
+    status_polling_period: float
+        Polling period for RE Manager status used by 'wait' operations,
+        default value: 1 second
+    loop: asyncio.Loop
+        ``asyncio`` event loop (use only with Async version of the API).
+        The parameter is included only for compatibility with 0MQ version
+        of the API and is ignored in HTTP version.
+
+    Examples
+    --------
+
+    Synchronous API:
+
+    .. code-block:: python
+
+        from bluesky_queueserver_api.http import REManagerAPI
+        RM = REManagerAPI()
+        # < some useful code >
+        RE.close()
+
+    Asynchronous API:
+
+    .. code-block:: python
+
+        from bluesky_queueserver_api.http.aio import REManagerAPI
+
+        async def testing():
+            RM = REManagerAPI()
+            # < some useful code >
+            await RE.close()
+
+        asyncio.run(testing())
+"""
+
+
 _doc_send_request = """
     Send request to RE Manager and receive the response. The function directly passes
     the request to low-level Queue Server API. The detailed description of available
@@ -154,25 +266,25 @@ _doc_send_request = """
 
     .. code-block:: python
 
-        # 0MQ, blocking
+        # Synchronous code (0MQ)
         from bluesky_queueserver_api.zmq import REManagerAPI
         RM = REManagerAPI()
         status = RM.send_request(method="status")
         RM.close()
 
-        # HTTP, blocking
+        # Synchronous code (HTTP)
         from bluesky_queueserver_api.http import REManagerAPI
         RM = REManagerAPI()
         status = RM.send_request(method="status")
         RM.close()
 
-        # 0MQ, async
+        # Asynchronous code (0MQ)
         from bluesky_queueserver_api.zmq.aio import REManagerAPI
         RM = REManagerAPI()
         status = await RM.send_request(method="status")
         await RM.close()
 
-        # HTTP, async
+        # Asynchronous code, (HTTP)
         from bluesky_queueserver_api.http.aio import REManagerAPI
         RM = REManagerAPI()
         status = await RM.send_request(method="status")
@@ -221,9 +333,102 @@ _doc_api_status = """
 
         # Synchronous code (0MQ and HTTP)
         status = RM.status()
-        status = RM.status(reload=True)
 
         # Asynchronous code (0MQ and HTTP)
         status = await RM.status()
-        status = await RM.status(reload=True)
+"""
+
+_doc_api_wait_for_idle = """
+    Wait for RE Manager to return to ``idle`` state. The function performs
+    periodic polling of RE Manager status and returns when ``manager_state``
+    status flag is ``idle``. Polling period is determined by ``status_polling_period``
+    parameter of ``REManagerAPI`` class. The function raises ``WaitTimeoutError``
+    if timeout occurs or ``WaitCancelError`` if wait operation was cancelled by
+    ``monitor.cancel()``. See instructions on ``WaitMonitor`` class, which allows
+    cancelling wait operations (from a different thread or task), modify timeout
+    and monitoring the progress.
+
+    ``wait_for_idle`` is threadsafe and could be run simultanously from multiple
+    threads with polled RE Manager status shared between multiple instances.
+
+    Parameters
+    ----------
+    timeout: float
+        Timeout for the wait operation. Default timeout: 60 seconds.
+    monitor: bluesky_queueserver_api.WaitMonitor or None
+        Instance of ``WaitMonitor`` object. The object is created internally if
+        the parameter is ``None``.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        # Synchronous code (0MQ, HTTP)
+        RM.queue_start()
+        try:
+            RM.wait_for_idle(timeout=120)  # Wait for 2 minutes
+            # < queue is completed or stopped, RE Manager is idle >
+        except RM.WaitTimeoutError:
+            # < process timeout error, RE Manager is probably not idle >
+
+        # Aynchronous code (0MQ, HTTP)
+        await RM.queue_start()
+        try:
+            await RM.wait_for_idle(timeout=120)  # Wait for 2 minutes
+            # < queue is completed or stopped, RE Manager is idle >
+        except RM.WaitTimeoutError:
+            # < process timeout error, RE Manager is probably not idle >
+"""
+
+_doc_api_item_add = """
+    Add item to the queue. The item may be a plan or an instruction represented
+    as a dictionary or as an instance of ``BItem``, ``BPlan`` or ``BInst`` classes.
+    By default the item is added to the back of the queue. Alternatively
+    the item can be placed at the desired position in the queue or before
+    or after one of the existing items. The parameters ``pos``, ``before_uid`` and
+    ``after_uid`` are mutually exclusive, i.e. only one of the parameters may
+    have a value different from ``None``.
+
+    Parameters
+    ----------
+    item: dict, BItem, BPlan or BInst
+        Dictionary or an instance of ``BItem``, ``BPlan`` or ``BInst`` representing
+        a plan or an instruction.
+    pos: str, int or None
+        Position of the item in the queue. RE Manager will attempt to insert the
+        item at the specified position. The position may be positive or negative
+        (counted from the back of the queue) integer. If ``pos`` value is a string
+        ``"front"`` or ``"back"``, then the item is inserted at the front or the back
+        of the queue. If the value is ``None``, then the position is not specified.
+    before_uid, after_uid: str or None
+        Insert the item before or after the item with the given item UID. If ``None``
+        (default), then the parameters are not specified.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        # Synchronous code (0MQ, HTTP)
+        # Add an item to the back of the queue
+        RM.item_add({"item_type": "plan", "name": "count", "args": [["det1"]]})
+        # Add an item to the front of the queue
+        RM.item_add(BItem("plan", "count", ["det1"], num=10, delay=1), pos="front")
+        RM.item_add(BItem("plan", "count", ["det1"], num=10, delay=1), pos=0)
+        # Insert an item to the position #5 (numbers start from 0)
+        RM.item_add(BPlan("count", ["det1"], num=10, delay=1), pos=5)
+        # Insert an item before the last item
+        RM.item_add(BPlan("count", ["det1"], num=10, delay=1), pos=-1)
+
+        # Asynchronous code (0MQ, HTTP)
+        # Add an item to the back of the queue
+        await RM.item_add({"item_type": "plan", "name": "count", "args": [["det1"]]})
+        # Add an item to the front of the queue
+        await RM.item_add(BItem("plan", "count", ["det1"], num=10, delay=1), pos="front")
+        await RM.item_add(BItem("plan", "count", ["det1"], num=10, delay=1), pos=0)
+        # Insert an item to the position #5 (numbers start from 0)
+        await RM.item_add(BPlan("count", ["det1"], num=10, delay=1), pos=5)
+        # Insert an item before the last item
+        await RM.item_add(BPlan("count", ["det1"], num=10, delay=1), pos=-1)
 """

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -5,7 +5,16 @@ import threading
 from .api_base import API_Base, WaitMonitor
 from ._defaults import default_wait_timeout
 
-from .api_docstrings import _doc_api_status, _doc_api_wait_for_idle, _doc_api_item_add
+from .api_docstrings import (
+    _doc_api_status,
+    _doc_api_wait_for_idle,
+    _doc_api_item_add,
+    _doc_api_item_get,
+    _doc_api_queue_start,
+    _doc_api_environment_open,
+    _doc_api_environment_close,
+    _doc_api_environment_destroy,
+)
 
 
 class API_Threads_Mixin(API_Base):
@@ -267,3 +276,8 @@ class API_Threads_Mixin(API_Base):
 API_Threads_Mixin.status.__doc__ = _doc_api_status
 API_Threads_Mixin.wait_for_idle.__doc__ = _doc_api_wait_for_idle
 API_Threads_Mixin.item_add.__doc__ = _doc_api_item_add
+API_Threads_Mixin.item_get.__doc__ = _doc_api_item_get
+API_Threads_Mixin.queue_start.__doc__ = _doc_api_queue_start
+API_Threads_Mixin.environment_open.__doc__ = _doc_api_environment_open
+API_Threads_Mixin.environment_close.__doc__ = _doc_api_environment_close
+API_Threads_Mixin.environment_destroy.__doc__ = _doc_api_environment_destroy

--- a/bluesky_queueserver_api/comm_base.py
+++ b/bluesky_queueserver_api/comm_base.py
@@ -12,13 +12,38 @@ from ._defaults import (
 
 
 rest_api_method_map = {
+    "ping": ("GET", "/ping"),
     "status": ("GET", "/status"),
     "queue_start": ("POST", "/queue/start"),
+    "queue_stop": ("POST", "/queue/stop"),
+    "queue_stop_cancel": ("POST", "/queue/stop/cancel"),
+    "queue_get": ("GET", "/queue/get"),
+    "queue_clear": ("POST", "/queue/clear"),
+    "queue_mode_set": ("POST", "/queue/mode/set"),
     "queue_item_add": ("POST", "/queue/item/add"),
+    "queue_item_add_batch": ("POST", "/queue/item/add/batch"),
     "queue_item_get": ("POST", "/queue/item/get"),
+    "queue_item_update": ("POST", "/queue/item/update"),
+    "queue_item_remove": ("POST", "/queue/item/remove"),
+    "queue_item_remove_batch": ("POST", "/queue/item/remove/batch"),
+    "queue_item_move": ("POST", "/queue/item/move"),
+    "queue_item_move_batch": ("POST", "/queue/item/move/batch"),
+    "queue_item_execute": ("POST", "/queue/item/execute"),
+    "history_get": ("GET", "/history/get"),
+    "history_clear": ("POST", "/history/clear"),
     "environment_open": ("POST", "/environment/open"),
     "environment_close": ("POST", "/environment/close"),
     "environment_destroy": ("POST", "/environment/destroy"),
+    "re_pause": ("POST", "/re/pause"),
+    "re_resume": ("POST", "/re/resume"),
+    "re_stop": ("POST", "/re/stop"),
+    "re_abort": ("POST", "/re/abort"),
+    "re_halt": ("POST", "/re/halt"),
+    "plans_allowed": ("GET", "/plans/allowed"),
+    "devices_allowed": ("GET", "/devices/allowed"),
+    "permissions_reload": ("POST", "/permissions/reload"),
+    "manager_stop": ("POST", "/manager/stop"),
+    "manager_kill": ("POST", "/test/manager/kill"),
 }
 
 

--- a/bluesky_queueserver_api/http/__init__.py
+++ b/bluesky_queueserver_api/http/__init__.py
@@ -1,21 +1,25 @@
 from ..api_threads import API_Threads_Mixin
 from ..comm_threads import ReManagerComm_HTTP_Threads
 
-
 from .._defaults import (
     default_allow_request_fail_exceptions,
     default_http_request_timeout,
-    default_http_server_uri,
+    default_status_expiration_period,
+    default_status_polling_period,
 )
+
+from ..api_docstrings import _doc_REManagerAPI_HTTP
 
 
 class REManagerAPI(ReManagerComm_HTTP_Threads, API_Threads_Mixin):
     def __init__(
         self,
         *,
-        http_server_uri=default_http_server_uri,
+        http_server_uri=None,
         timeout=default_http_request_timeout,
         request_fail_exceptions=default_allow_request_fail_exceptions,
+        status_expiration_period=default_status_expiration_period,
+        status_polling_period=default_status_polling_period,
     ):
         ReManagerComm_HTTP_Threads.__init__(
             self,
@@ -23,4 +27,11 @@ class REManagerAPI(ReManagerComm_HTTP_Threads, API_Threads_Mixin):
             timeout=timeout,
             request_fail_exceptions=request_fail_exceptions,
         )
-        API_Threads_Mixin.__init__(self)
+        API_Threads_Mixin.__init__(
+            self,
+            status_expiration_period=status_expiration_period,
+            status_polling_period=status_polling_period,
+        )
+
+
+REManagerAPI.__doc__ = _doc_REManagerAPI_HTTP

--- a/bluesky_queueserver_api/http/aio.py
+++ b/bluesky_queueserver_api/http/aio.py
@@ -1,21 +1,25 @@
 from ..api_async import API_Async_Mixin
 from ..comm_async import ReManagerComm_HTTP_Async
 
-
 from .._defaults import (
     default_allow_request_fail_exceptions,
     default_http_request_timeout,
-    default_http_server_uri,
+    default_status_expiration_period,
+    default_status_polling_period,
 )
+
+from ..api_docstrings import _doc_REManagerAPI_HTTP
 
 
 class REManagerAPI(ReManagerComm_HTTP_Async, API_Async_Mixin):
     def __init__(
         self,
         *,
-        http_server_uri=default_http_server_uri,
+        http_server_uri=None,
         timeout=default_http_request_timeout,
         request_fail_exceptions=default_allow_request_fail_exceptions,
+        status_expiration_period=default_status_expiration_period,
+        status_polling_period=default_status_polling_period,
         loop=None,  # Ignored, used here for compatibility with 0MQ asyncio API
     ):
         ReManagerComm_HTTP_Async.__init__(
@@ -24,4 +28,11 @@ class REManagerAPI(ReManagerComm_HTTP_Async, API_Async_Mixin):
             timeout=timeout,
             request_fail_exceptions=request_fail_exceptions,
         )
-        API_Async_Mixin.__init__(self)
+        API_Async_Mixin.__init__(
+            self,
+            status_expiration_period=status_expiration_period,
+            status_polling_period=status_polling_period,
+        )
+
+
+REManagerAPI.__doc__ = _doc_REManagerAPI_HTTP

--- a/bluesky_queueserver_api/zmq/__init__.py
+++ b/bluesky_queueserver_api/zmq/__init__.py
@@ -4,10 +4,15 @@ from .._defaults import (
     default_allow_request_fail_exceptions,
     default_zmq_request_timeout_recv,
     default_zmq_request_timeout_send,
+    default_status_expiration_period,
+    default_status_polling_period,
 )
+
+from ..api_docstrings import _doc_REManagerAPI_ZMQ
 
 
 class REManagerAPI(ReManagerComm_ZMQ_Threads, API_Threads_Mixin):
+    # docstring is maintained separately
     def __init__(
         self,
         *,
@@ -16,6 +21,8 @@ class REManagerAPI(ReManagerComm_ZMQ_Threads, API_Threads_Mixin):
         timeout_send=default_zmq_request_timeout_send,
         server_public_key=None,
         request_fail_exceptions=default_allow_request_fail_exceptions,
+        status_expiration_period=default_status_expiration_period,
+        status_polling_period=default_status_polling_period,
     ):
         ReManagerComm_ZMQ_Threads.__init__(
             self,
@@ -25,4 +32,11 @@ class REManagerAPI(ReManagerComm_ZMQ_Threads, API_Threads_Mixin):
             server_public_key=server_public_key,
             request_fail_exceptions=request_fail_exceptions,
         )
-        API_Threads_Mixin.__init__(self)
+        API_Threads_Mixin.__init__(
+            self,
+            status_expiration_period=status_expiration_period,
+            status_polling_period=status_polling_period,
+        )
+
+
+REManagerAPI.__doc__ = _doc_REManagerAPI_ZMQ

--- a/bluesky_queueserver_api/zmq/aio.py
+++ b/bluesky_queueserver_api/zmq/aio.py
@@ -4,10 +4,15 @@ from .._defaults import (
     default_allow_request_fail_exceptions,
     default_zmq_request_timeout_recv,
     default_zmq_request_timeout_send,
+    default_status_expiration_period,
+    default_status_polling_period,
 )
+
+from ..api_docstrings import _doc_REManagerAPI_ZMQ
 
 
 class REManagerAPI(ReManagerComm_ZMQ_Async, API_Async_Mixin):
+    # docstring is maintained separately
     def __init__(
         self,
         *,
@@ -16,6 +21,8 @@ class REManagerAPI(ReManagerComm_ZMQ_Async, API_Async_Mixin):
         timeout_send=default_zmq_request_timeout_send,
         server_public_key=None,
         request_fail_exceptions=default_allow_request_fail_exceptions,
+        status_expiration_period=default_status_expiration_period,
+        status_polling_period=default_status_polling_period,
         loop=None,
     ):
         ReManagerComm_ZMQ_Async.__init__(
@@ -27,4 +34,11 @@ class REManagerAPI(ReManagerComm_ZMQ_Async, API_Async_Mixin):
             request_fail_exceptions=request_fail_exceptions,
             loop=loop,
         )
-        API_Async_Mixin.__init__(self)
+        API_Async_Mixin.__init__(
+            self,
+            status_expiration_period=status_expiration_period,
+            status_polling_period=status_polling_period,
+        )
+
+
+REManagerAPI.__doc__ = _doc_REManagerAPI_ZMQ

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -37,6 +37,22 @@ Type-Specific Queue Items
     BInst
     BFunc
 
+Miscellaneous API
+-----------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated
+
+    WaitMonitor
+    WaitMonitor.cancel
+    WaitMonitor.is_cancelled
+    WaitMonitor.time_start
+    WaitMonitor.time_elapsed
+    WaitMonitor.timeout
+    WaitMonitor.set_timeout
+    WaitMonitor.add_cancel_callback
+
 Synchronous Communication with 0MQ Server
 -----------------------------------------
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Changes in this PR:

- Docstrings for existing API. 

- Added all endpoints currently supported by `bluesky-httpserver` (except `/re/runs`). `bluesky-httpserver` does not support the API that were added recently.
