### PR TITLE
Renamed parameters of 'permissions_reload' API

### DIFF
--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -461,10 +461,10 @@ class API_Async_Mixin(API_Base):
             response = self._generate_response_devices_existing()
         return response
 
-    async def permissions_reload(self, *, reload_plans_devices=None, reload_permissions=None):
+    async def permissions_reload(self, *, restore_plans_devices=None, restore_permissions=None):
         # Docstring is maintained separately
         request_params = self._prepare_permissions_reload(
-            reload_plans_devices=reload_plans_devices, reload_permissions=reload_permissions
+            restore_plans_devices=restore_plans_devices, restore_permissions=restore_permissions
         )
         self._clear_status_timestamp()
         return await self.send_request(method="permissions_reload", params=request_params)

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -458,13 +458,13 @@ class API_Base:
         }
         return response
 
-    def _prepare_permissions_reload(self, *, reload_plans_devices, reload_permissions):
+    def _prepare_permissions_reload(self, *, restore_plans_devices, restore_permissions):
         """
         Prepare parameters for ``permissions_reload``
         """
         request_params = {}
-        self._add_request_param(request_params, "reload_plans_devices", reload_plans_devices)
-        self._add_request_param(request_params, "reload_permissions", reload_permissions)
+        self._add_request_param(request_params, "restore_plans_devices", restore_plans_devices)
+        self._add_request_param(request_params, "restore_permissions", restore_permissions)
         return request_params
 
     def _prepare_permissions_set(self, *, user_group_permissions):

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -1271,16 +1271,16 @@ _doc_api_permissions_reload = """
     command line parameters and generate lists of allowed plans and devices based on
     the lists of existing plans and devices. By default, the method will use current
     lists of existing plans and devices stored in memory. Optionally the method can
-    reload the lists from the disk file (see reload_plans_devices parameter).
+    reload the lists from the disk file (see ``restore_plans_devices`` parameter).
     The method always updates UIDs of the lists of allowed plans and devices even
     if the contents remain the same.
 
     Parameters
     ----------
-    reload_plans_devices: boolean (optional)
+    restore_plans_devices: boolean (optional)
         Reload the lists of existing plans and devices from disk if True, otherwise
         use current lists stored in memory. Default: False.
-    reload_permissions: boolean (optional)
+    restore_permissions: boolean (optional)
         Reload user group permissions from disk if True, otherwise use current
         permissions. Default: True.
 

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -464,10 +464,10 @@ class API_Threads_Mixin(API_Base):
             response = self._generate_response_devices_existing()
         return response
 
-    def permissions_reload(self, *, reload_plans_devices=None, reload_permissions=None):
+    def permissions_reload(self, *, restore_plans_devices=None, restore_permissions=None):
         # Docstring is maintained separately
         request_params = self._prepare_permissions_reload(
-            reload_plans_devices=reload_plans_devices, reload_permissions=reload_permissions
+            restore_plans_devices=restore_plans_devices, restore_permissions=restore_permissions
         )
         self._clear_status_timestamp()
         return self.send_request(method="permissions_reload", params=request_params)

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -1467,7 +1467,7 @@ def test_permissions_get_set_01(re_manager, fastapi_server, protocol, library): 
         assert allowed_plans == {}
 
         # Do not reload permssions from disk
-        resp5 = RM.permissions_reload(reload_permissions=False)
+        resp5 = RM.permissions_reload(restore_permissions=False)
         assert resp5["success"] is True
 
         resp6 = RM.plans_allowed()
@@ -1477,7 +1477,7 @@ def test_permissions_get_set_01(re_manager, fastapi_server, protocol, library): 
         assert allowed_plans == {}
 
         # Reload permssions from disk
-        resp6 = RM.permissions_reload(reload_permissions=True)
+        resp6 = RM.permissions_reload(restore_permissions=True)
         assert resp6["success"] is True
 
         resp7 = RM.plans_allowed()
@@ -1515,7 +1515,7 @@ def test_permissions_get_set_01(re_manager, fastapi_server, protocol, library): 
             assert allowed_plans == {}
 
             # Do not reload permssions from disk
-            resp5 = await RM.permissions_reload(reload_permissions=False)
+            resp5 = await RM.permissions_reload(restore_permissions=False)
             assert resp5["success"] is True
 
             resp6 = await RM.plans_allowed()
@@ -1525,7 +1525,7 @@ def test_permissions_get_set_01(re_manager, fastapi_server, protocol, library): 
             assert allowed_plans == {}
 
             # Reload permssions from disk
-            resp6 = await RM.permissions_reload(reload_permissions=True)
+            resp6 = await RM.permissions_reload(restore_permissions=True)
             assert resp6["success"] is True
 
             resp7 = await RM.plans_allowed()

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     long_description=readme,
     author="Brookhaven National Laboratory",
     author_email="",
-    url="https://github.com/dmgav/bluesky-queueserver-api",
+    url="https://github.com/bluesky/bluesky-queueserver-api",
     python_requires=">={}".format(".".join(str(n) for n in min_version)),
     packages=find_packages(exclude=["docs", "tests"]),
     entry_points={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Renamed parameters of permissions_reload API: `reload_permissions` is renamed to `restore_permissions`, `reload_plans_devices` is renamed to `restore_plans_devices`. Related PR: https://github.com/bluesky/bluesky-queueserver/pull/220.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed
Renamed parameters of permissions_reload API: `reload_permissions` is renamed to `restore_permissions`, `reload_plans_devices` is renamed to `restore_plans_devices`.

### Removed

