### PR TITLE
Proper handling of communication/server errors in 'wait_..' API

### DIFF
--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -207,6 +207,12 @@ class API_Async_Mixin(API_Base):
                 except Exception:
                     pass
 
+        # Attempt to load the updated status
+        try:
+            await self._status(reload=True)
+        except Exception:
+            pass
+
         if timeout_occurred:
             raise self.WaitTimeoutError("Timeout while waiting for condition")
         if wait_cancelled:

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -202,7 +202,11 @@ class API_Threads_Mixin(API_Base):
                 except Exception:
                     pass
 
-        self._status(reload=True)  # Load the updated status
+        # Attempt to load the updated status
+        try:
+            self._status(reload=True)
+        except Exception:
+            pass
 
         if timeout_occurred:
             raise self.WaitTimeoutError("Timeout while waiting for condition")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix: catch and internally handle all exceptions raised by communication functions in `wait_..` API (such as `wait_for_idle` API). If the server is not accessible or status requests to server fail, then `wait_..` API calls are supposed to time out.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
