### PR TITLE
Extension of Console Monitor: text buffer

### DIFF
--- a/bluesky_queueserver_api/_defaults.py
+++ b/bluesky_queueserver_api/_defaults.py
@@ -6,6 +6,7 @@ default_status_polling_period = 1.0  # s
 default_console_monitor_poll_timeout = 1.0  # s, 0MQ
 default_console_monitor_poll_period = 0.5  # s, HTTP
 default_console_monitor_max_msgs = 10000
+default_console_monitor_max_lines = 1000
 
 default_zmq_request_timeout_recv = 2.0  # s
 default_zmq_request_timeout_send = 0.5  # s

--- a/bluesky_queueserver_api/comm_async.py
+++ b/bluesky_queueserver_api/comm_async.py
@@ -13,6 +13,7 @@ class ReManagerComm_ZMQ_Async(ReManagerAPI_ZMQ_Base):
             zmq_subscribe_addr=self._zmq_subscribe_addr,
             poll_timeout=self._console_monitor_poll_timeout,
             max_msgs=self._console_monitor_max_msgs,
+            max_lines=self._console_monitor_max_lines,
         )
 
     def _create_client(
@@ -51,6 +52,7 @@ class ReManagerComm_HTTP_Async(ReManagerAPI_HTTP_Base):
             parent=self,
             poll_period=self._console_monitor_poll_period,
             max_msgs=self._console_monitor_max_msgs,
+            max_lines=self._console_monitor_max_lines,
         )
 
     def _create_client(self, http_server_uri, timeout):

--- a/bluesky_queueserver_api/comm_base.py
+++ b/bluesky_queueserver_api/comm_base.py
@@ -11,6 +11,7 @@ from ._defaults import (
     default_console_monitor_poll_timeout,
     default_console_monitor_poll_period,
     default_console_monitor_max_msgs,
+    default_console_monitor_max_lines,
 )
 
 
@@ -147,6 +148,7 @@ class ReManagerAPI_ZMQ_Base(ReManagerAPI_Base):
         timeout_send=default_zmq_request_timeout_send,
         console_monitor_poll_timeout=default_console_monitor_poll_timeout,
         console_monitor_max_msgs=default_console_monitor_max_msgs,
+        console_monitor_max_lines=default_console_monitor_max_lines,
         server_public_key=None,
         request_fail_exceptions=default_allow_request_fail_exceptions,
     ):
@@ -159,6 +161,7 @@ class ReManagerAPI_ZMQ_Base(ReManagerAPI_Base):
         self._zmq_subscribe_addr = zmq_subscribe_addr
         self._console_monitor_poll_timeout = console_monitor_poll_timeout
         self._console_monitor_max_msgs = console_monitor_max_msgs
+        self._console_monitor_max_lines = console_monitor_max_lines
 
         self._client = self._create_client(
             zmq_server_address=zmq_server_address,
@@ -194,6 +197,7 @@ class ReManagerAPI_HTTP_Base(ReManagerAPI_Base):
         timeout=default_http_request_timeout,
         console_monitor_poll_period=default_console_monitor_poll_period,
         console_monitor_max_msgs=default_console_monitor_max_msgs,
+        console_monitor_max_lines=default_console_monitor_max_lines,
         request_fail_exceptions=default_allow_request_fail_exceptions,
     ):
         super().__init__(request_fail_exceptions=request_fail_exceptions)
@@ -210,6 +214,7 @@ class ReManagerAPI_HTTP_Base(ReManagerAPI_Base):
         self._request_fail_exceptions = request_fail_exceptions
         self._console_monitor_poll_period = console_monitor_poll_period
         self._console_monitor_max_msgs = console_monitor_max_msgs
+        self._console_monitor_max_lines = console_monitor_max_lines
 
         self._rest_api_method_map = rest_api_method_map
 

--- a/bluesky_queueserver_api/comm_threads.py
+++ b/bluesky_queueserver_api/comm_threads.py
@@ -13,6 +13,7 @@ class ReManagerComm_ZMQ_Threads(ReManagerAPI_ZMQ_Base):
             zmq_subscribe_addr=self._zmq_subscribe_addr,
             poll_timeout=self._console_monitor_poll_timeout,
             max_msgs=self._console_monitor_max_msgs,
+            max_lines=self._console_monitor_max_lines,
         )
 
     def _create_client(
@@ -51,6 +52,7 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
             parent=self,
             poll_period=self._console_monitor_poll_period,
             max_msgs=self._console_monitor_max_msgs,
+            max_lines=self._console_monitor_max_lines,
         )
 
     def _create_client(self, http_server_uri, timeout):

--- a/bluesky_queueserver_api/console_monitor.py
+++ b/bluesky_queueserver_api/console_monitor.py
@@ -333,7 +333,7 @@ class _ConsoleMonitor:
         self._text_updated = True
 
     def _add_msg_to_text_buffer(self, response):
-        _, msg = response
+        msg = response["msg"]
 
         pattern_new_line = "\n"
         pattern_cr = "\r"
@@ -360,12 +360,13 @@ class _ConsoleMonitor:
                 # Extend the current line with spaces if needed
                 line_len = len(self._text_buffer[self._text_line])
                 if line_len < self._text_pos:
-                    self._text_buffer[self._text_line] += " " * self._text_pos - line_len
+                    self._text_buffer[self._text_line] += " " * (self._text_pos - line_len)
 
                 line = self._text_buffer[self._text_line]
                 self._text_buffer[self._text_line] = (
                     line[: self._text_pos] + substr + line[self._text_pos + len(substr) :]
                 )
+                self._text_pos = self._text_pos + len(substr)
 
             elif indices["new_line"] == 0:
                 self._text_line += 1
@@ -386,7 +387,11 @@ class _ConsoleMonitor:
         self._text_updated = True
 
     def _adjust_text_buffer_size(self):
-        max_lines = self._text_max_lines
+        if self._text_buffer and self._text_buffer[-1] == "":
+            # Do not count an empty string at the end
+            max_lines = self._text_max_lines + 1
+        else:
+            max_lines = self._text_max_lines
 
         if len(self._text_buffer) > max_lines:
             # Remove extra lines from the beginning of the list

--- a/bluesky_queueserver_api/http/__init__.py
+++ b/bluesky_queueserver_api/http/__init__.py
@@ -8,6 +8,7 @@ from .._defaults import (
     default_status_polling_period,
     default_console_monitor_poll_period,
     default_console_monitor_max_msgs,
+    default_console_monitor_max_lines,
 )
 
 from ..api_docstrings import _doc_REManagerAPI_HTTP
@@ -21,6 +22,7 @@ class REManagerAPI(ReManagerComm_HTTP_Threads, API_Threads_Mixin):
         timeout=default_http_request_timeout,
         console_monitor_poll_period=default_console_monitor_poll_period,
         console_monitor_max_msgs=default_console_monitor_max_msgs,
+        console_monitor_max_lines=default_console_monitor_max_lines,
         request_fail_exceptions=default_allow_request_fail_exceptions,
         status_expiration_period=default_status_expiration_period,
         status_polling_period=default_status_polling_period,
@@ -31,6 +33,7 @@ class REManagerAPI(ReManagerComm_HTTP_Threads, API_Threads_Mixin):
             timeout=timeout,
             console_monitor_poll_period=console_monitor_poll_period,
             console_monitor_max_msgs=console_monitor_max_msgs,
+            console_monitor_max_lines=console_monitor_max_lines,
             request_fail_exceptions=request_fail_exceptions,
         )
         API_Threads_Mixin.__init__(

--- a/bluesky_queueserver_api/http/aio.py
+++ b/bluesky_queueserver_api/http/aio.py
@@ -8,6 +8,7 @@ from .._defaults import (
     default_status_polling_period,
     default_console_monitor_poll_period,
     default_console_monitor_max_msgs,
+    default_console_monitor_max_lines,
 )
 
 from ..api_docstrings import _doc_REManagerAPI_HTTP
@@ -21,6 +22,7 @@ class REManagerAPI(ReManagerComm_HTTP_Async, API_Async_Mixin):
         timeout=default_http_request_timeout,
         console_monitor_poll_period=default_console_monitor_poll_period,
         console_monitor_max_msgs=default_console_monitor_max_msgs,
+        console_monitor_max_lines=default_console_monitor_max_lines,
         request_fail_exceptions=default_allow_request_fail_exceptions,
         status_expiration_period=default_status_expiration_period,
         status_polling_period=default_status_polling_period,
@@ -31,6 +33,7 @@ class REManagerAPI(ReManagerComm_HTTP_Async, API_Async_Mixin):
             timeout=timeout,
             console_monitor_poll_period=console_monitor_poll_period,
             console_monitor_max_msgs=console_monitor_max_msgs,
+            console_monitor_max_lines=console_monitor_max_lines,
             request_fail_exceptions=request_fail_exceptions,
         )
         API_Async_Mixin.__init__(

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -2118,9 +2118,12 @@ def test_console_monitor_01(re_manager_cmd, fastapi_server, read_timeout, option
                 break
 
         text = "".join(text)
+        text2 = RM.console_monitor.text()
         print(f"============= text=\n'{text}'")
+        print(f"============= text2=\n'{text2}'")
         print(f"============= expected_output=\n'{expected_output}'")
         assert expected_output in text
+        assert expected_output in text2
 
         RM.console_monitor.disable()
         assert RM.console_monitor.enabled is False
@@ -2175,9 +2178,12 @@ def test_console_monitor_01(re_manager_cmd, fastapi_server, read_timeout, option
                     break
 
             text = "".join(text)
+            text2 = await RM.console_monitor.text()
             print(f"============= text=\n{text}")
+            print(f"============= text2=\n'{text2}'")
             print(f"============= expected_output=\n{expected_output}")
             assert expected_output in text
+            assert expected_output in text2
 
             RM.console_monitor.disable()
             assert RM.console_monitor.enabled is False
@@ -2218,6 +2224,9 @@ def test_console_monitor_02(re_manager_cmd, fastapi_server, library, protocol): 
             RM.console_monitor.next_msg(timeout=2)  # Raises an exception after 2 sec. timeout
         assert ttime.time() - t0 > 1.9
 
+        # There should be no accumulated output
+        assert RM.console_monitor.text() == ""
+
         RM.close()
 
     else:
@@ -2237,6 +2246,9 @@ def test_console_monitor_02(re_manager_cmd, fastapi_server, library, protocol): 
             with pytest.raises(RM.RequestTimeoutError):
                 await RM.console_monitor.next_msg(timeout=2)  # Raises an exception after 2 sec. timeout
             assert ttime.time() - t0 > 1.9
+
+            # There should be no accumulated output
+            assert await RM.console_monitor.text() == ""
 
             await RM.close()
 
@@ -2332,6 +2344,7 @@ def test_console_monitor_04(re_manager_cmd, fastapi_server, library, protocol): 
 
         with pytest.raises(RM.RequestTimeoutError):
             RM.console_monitor.next_msg()
+        assert RM.console_monitor.text() == ""
 
         RM.close()
 
@@ -2350,6 +2363,7 @@ def test_console_monitor_04(re_manager_cmd, fastapi_server, library, protocol): 
 
             with pytest.raises(RM.RequestTimeoutError):
                 await RM.console_monitor.next_msg()
+            assert await RM.console_monitor.text() == ""
 
             await RM.close()
 

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -2628,6 +2628,10 @@ def test_console_monitor_07(
         else:
             assert text != ""
 
+            RM.console_monitor.text_max_lines = 3
+            text2 = RM.console_monitor.text()
+            assert len(text2.split("\n")) == 3, text2
+
         RM.close()
 
     else:
@@ -2656,6 +2660,10 @@ def test_console_monitor_07(
                 assert text == ""
             else:
                 assert text != ""
+
+                RM.console_monitor.text_max_lines = 3
+                text2 = await RM.console_monitor.text()
+                assert len(text2.split("\n")) == 3, text2
 
             await RM.close()
 

--- a/bluesky_queueserver_api/zmq/__init__.py
+++ b/bluesky_queueserver_api/zmq/__init__.py
@@ -6,6 +6,7 @@ from .._defaults import (
     default_zmq_request_timeout_send,
     default_console_monitor_poll_timeout,
     default_console_monitor_max_msgs,
+    default_console_monitor_max_lines,
     default_status_expiration_period,
     default_status_polling_period,
 )
@@ -24,6 +25,7 @@ class REManagerAPI(ReManagerComm_ZMQ_Threads, API_Threads_Mixin):
         timeout_send=default_zmq_request_timeout_send,
         console_monitor_poll_timeout=default_console_monitor_poll_timeout,
         console_monitor_max_msgs=default_console_monitor_max_msgs,
+        console_monitor_max_lines=default_console_monitor_max_lines,
         server_public_key=None,
         request_fail_exceptions=default_allow_request_fail_exceptions,
         status_expiration_period=default_status_expiration_period,
@@ -37,6 +39,7 @@ class REManagerAPI(ReManagerComm_ZMQ_Threads, API_Threads_Mixin):
             timeout_send=timeout_send,
             console_monitor_poll_timeout=console_monitor_poll_timeout,
             console_monitor_max_msgs=console_monitor_max_msgs,
+            console_monitor_max_lines=console_monitor_max_lines,
             server_public_key=server_public_key,
             request_fail_exceptions=request_fail_exceptions,
         )

--- a/bluesky_queueserver_api/zmq/aio.py
+++ b/bluesky_queueserver_api/zmq/aio.py
@@ -6,6 +6,7 @@ from .._defaults import (
     default_zmq_request_timeout_send,
     default_console_monitor_poll_timeout,
     default_console_monitor_max_msgs,
+    default_console_monitor_max_lines,
     default_status_expiration_period,
     default_status_polling_period,
 )
@@ -24,6 +25,7 @@ class REManagerAPI(ReManagerComm_ZMQ_Async, API_Async_Mixin):
         timeout_send=default_zmq_request_timeout_send,
         console_monitor_poll_timeout=default_console_monitor_poll_timeout,
         console_monitor_max_msgs=default_console_monitor_max_msgs,
+        console_monitor_max_lines=default_console_monitor_max_lines,
         server_public_key=None,
         request_fail_exceptions=default_allow_request_fail_exceptions,
         status_expiration_period=default_status_expiration_period,
@@ -37,6 +39,7 @@ class REManagerAPI(ReManagerComm_ZMQ_Async, API_Async_Mixin):
             timeout_send=timeout_send,
             console_monitor_poll_timeout=console_monitor_poll_timeout,
             console_monitor_max_msgs=console_monitor_max_msgs,
+            console_monitor_max_lines=console_monitor_max_lines,
             server_public_key=server_public_key,
             request_fail_exceptions=request_fail_exceptions,
         )

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -197,6 +197,9 @@ HTTP communication), which expose identical API. The class for monitoring consol
     console_monitor.ConsoleMonitor_ZMQ_Threads.disable_wait
     console_monitor.ConsoleMonitor_ZMQ_Threads.clear
     console_monitor.ConsoleMonitor_ZMQ_Threads.next_msg
+    console_monitor.ConsoleMonitor_ZMQ_Threads.text_max_lines
+    console_monitor.ConsoleMonitor_ZMQ_Threads.text_updated
+    console_monitor.ConsoleMonitor_ZMQ_Threads.text
 
 Other console monitor classes support identical API:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Extension of `REManagerAPI.console_monitor`. Updated console monitor is maintaining a text buffer that supports ASCII control characters used for displaying progress bars. The buffer may be extended to support other control characters. The number of buffered lines may be changed at any moment using `REManagerAPI.console_monitor.text_max_lines` property. Current text output generated from buffered lines may be loaded using `REManagerAPI.console_monitor.text()` method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The PR includes planned extension of the existing functionality.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Support for text buffer in `RE.console_monitor`.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were implemented.

<!--
## Screenshots (if appropriate):
-->
