### PR TITLE
'RE.console_monitor.text()' API: 'nlines' parameter

### DIFF
--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -144,6 +144,8 @@ _doc_REManagerAPI_ZMQ = """
     console_monitor_max_msgs: int
         Maximum number of messages in the internal message queue of
         the console monitor. Default: 10000.
+    console_monitor_max_lines: int
+        Maximum number of lines in the internal text buffer. Default: 1000.
     server_public_key: str or None
         Public key of RE Manager if the encryption is enabled. Set to ``None``
         if encryption is not enabled
@@ -203,6 +205,8 @@ _doc_REManagerAPI_HTTP = """
     console_monitor_max_msgs: int
         Maximum number of messages in the internal message buffer.
         Default: 10000.
+    console_monitor_max_lines: int
+        Maximum number of lines in the internal text buffer. Default: 1000.
     request_fail_exceptions: boolean
         If ``True`` (default) then API functions that communicate with
         RE Manager are raising the ``RequestFailError`` exception if

--- a/bluesky_queueserver_api/console_monitor.py
+++ b/bluesky_queueserver_api/console_monitor.py
@@ -272,7 +272,15 @@ _doc_ConsoleMonitor_text_max_lines = """
 _doc_ConsoleMonitor_text = """
     Returns text representation of console output. Monitor ``text_updated``
     property to check if text buffer was modified since the last call to
-    ``text()`` API.
+    ``text()`` API. The parameter ``nlines`` determines the maximum number
+    of lines of text returned by the function.
+
+    Parameters
+    ----------
+    nlines: int
+        Number of lines to return. The value determines the maximum number of lines
+        of text returned by the function. The function returns ``""`` (empty string)
+        if the value is ``0`` or negative.
 
     Returns
     -------
@@ -295,6 +303,10 @@ _doc_ConsoleMonitor_text = """
         text = RM.console_monitor.text()
         print(text)
 
+        # Return the last 10 lines
+        text = RM.console_monitor.text(10)
+        print(text)
+
         RM.console_monitor.disable()
 
     Asynchronous API
@@ -310,8 +322,11 @@ _doc_ConsoleMonitor_text = """
         text = await RM.console_monitor.text()
         print(text)
 
-        RM.console_monitor.disable()
+        # Return the last 10 lines
+        text = await RM.console_monitor.text(10)
+        print(text)
 
+        RM.console_monitor.disable()
 """
 
 

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -2673,6 +2673,7 @@ def test_console_monitor_07(
 # fmt: off
 @pytest.mark.parametrize("library", ["THREADS", "ASYNC"])
 @pytest.mark.parametrize("protocol", ["ZMQ", "HTTP"])
+# @pytest.mark.parametrize("protocol", ["HTTP"])
 # fmt: on
 def test_console_monitor_08(re_manager_cmd, fastapi_server, library, protocol):  # noqa: F811
     """
@@ -2693,6 +2694,7 @@ def test_console_monitor_08(re_manager_cmd, fastapi_server, library, protocol): 
         RM.console_monitor.enable()
         assert RM.console_monitor.enabled is True
         ttime.sleep(1)
+        text_uid0 = RM.console_monitor.text_uid
 
         # Generate some console output
         check_resp(RM.environment_open())
@@ -2701,11 +2703,11 @@ def test_console_monitor_08(re_manager_cmd, fastapi_server, library, protocol): 
         RM.wait_for_idle(timeout=10)
         ttime.sleep(1)  # Wait until all console output is loaded
 
-        assert RM.console_monitor.text_updated is True
+        text_uid1 = RM.console_monitor.text_uid
         text1 = RM.console_monitor.text()
+        assert text_uid1 != text_uid0
         n_text1 = len(text1.split("\n"))
         assert n_text1 > 0
-        assert RM.console_monitor.text_updated is False
         assert RM.console_monitor.text() == text1
 
         assert RM.console_monitor.text(n_text1) == text1
@@ -2726,13 +2728,18 @@ def test_console_monitor_08(re_manager_cmd, fastapi_server, library, protocol): 
 
         assert RM.console_monitor.text() == text1
 
+        assert RM.console_monitor.text_uid == text_uid1
+
         RM.console_monitor.clear()
-        assert RM.console_monitor.text_updated is True
+        text_uid2 = RM.console_monitor.text_uid
+        assert text_uid2 != text_uid1
 
         assert RM.console_monitor.text() == ""
         assert RM.console_monitor.text(100000) == ""
         assert RM.console_monitor.text(0) == ""
         assert RM.console_monitor.text(-1) == ""
+
+        assert RM.console_monitor.text_uid == text_uid2
 
         RM.close()
 
@@ -2745,6 +2752,7 @@ def test_console_monitor_08(re_manager_cmd, fastapi_server, library, protocol): 
             RM.console_monitor.enable()
             assert RM.console_monitor.enabled is True
             asyncio.sleep(1)
+            text_uid0 = RM.console_monitor.text_uid
 
             # Generate some console output
             check_resp(await RM.environment_open())
@@ -2753,11 +2761,11 @@ def test_console_monitor_08(re_manager_cmd, fastapi_server, library, protocol): 
             await RM.wait_for_idle(timeout=10)
             asyncio.sleep(1)
 
-            assert RM.console_monitor.text_updated is True
+            text_uid1 = RM.console_monitor.text_uid
             text1 = await RM.console_monitor.text()
+            assert text_uid1 != text_uid0
             n_text1 = len(text1.split("\n"))
             assert n_text1 > 0
-            assert RM.console_monitor.text_updated is False
             assert await RM.console_monitor.text() == text1
 
             assert await RM.console_monitor.text(n_text1) == text1
@@ -2778,13 +2786,18 @@ def test_console_monitor_08(re_manager_cmd, fastapi_server, library, protocol): 
 
             assert await RM.console_monitor.text() == text1
 
+            assert RM.console_monitor.text_uid == text_uid1
+
             RM.console_monitor.clear()
-            assert RM.console_monitor.text_updated is True
+            text_uid2 = RM.console_monitor.text_uid
+            assert text_uid2 != text_uid1
 
             assert await RM.console_monitor.text() == ""
             assert await RM.console_monitor.text(100000) == ""
             assert await RM.console_monitor.text(0) == ""
             assert await RM.console_monitor.text(-1) == ""
+
+            assert RM.console_monitor.text_uid == text_uid2
 
             await RM.close()
 

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -2407,12 +2407,12 @@ def test_console_monitor_05(
 
         RM = rm_api_class()
 
-        RM.environment_open()
-        RM.wait_for_idle(timeout=10)
-
         RM.console_monitor.enable()
         assert RM.console_monitor.enabled is True
         ttime.sleep(1)
+
+        RM.environment_open()
+        RM.wait_for_idle(timeout=10)
 
         RM.script_upload(script)
         ttime.sleep(2)
@@ -2436,12 +2436,12 @@ def test_console_monitor_05(
 
             RM = rm_api_class()
 
-            await RM.environment_open()
-            await RM.wait_for_idle(timeout=10)
-
             RM.console_monitor.enable()
             assert RM.console_monitor.enabled is True
             asyncio.sleep(1)
+
+            await RM.environment_open()
+            await RM.wait_for_idle(timeout=10)
 
             await RM.script_upload(script)
             asyncio.sleep(2)

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -198,7 +198,7 @@ HTTP communication), which expose identical API. The class for monitoring consol
     console_monitor.ConsoleMonitor_ZMQ_Threads.clear
     console_monitor.ConsoleMonitor_ZMQ_Threads.next_msg
     console_monitor.ConsoleMonitor_ZMQ_Threads.text_max_lines
-    console_monitor.ConsoleMonitor_ZMQ_Threads.text_updated
+    console_monitor.ConsoleMonitor_ZMQ_Threads.text_uid
     console_monitor.ConsoleMonitor_ZMQ_Threads.text
 
 Other console monitor classes support identical API:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add `nlines` parameter to `RE.console_monitor.text()` API. The value specifies the maximum number of lines returned by the function. The property `text_updated` is replaced with `text_uid`, which returns UID of the text buffer. The UID is updated each time the contents of the buffer is changed and may be used for monitor the state of the buffer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The changes were required to replace custom console monitoring class in HTTP server with `RM.console_monitor`. 

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- A parameter `nlines` was added to `REManagerAPI.console_monitor.text()` API. The parameter specifies the maximum number of lines returned by the function.

### Changed

- `REManagerAPI.console_monitor.text_updated` property was replaced with `...text_uid` property as more appropriate for monitoring of the state of the text buffer.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were implemented to test the new functionality.

<!--
## Screenshots (if appropriate):
-->
