### PR TITLE
Features for multi-user applications (external management of 'user' and 'user_group' information)

### DIFF
--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -429,7 +429,7 @@ class API_Async_Mixin(API_Base):
         # Docstring is maintained separately
         status = await self._status(reload=reload)
         plans_allowed_uid = status["plans_allowed_uid"]
-        user_group = self._get_user_group_for_allowed_plans_devices(user_group)
+        user_group = self._get_user_group_for_allowed_plans_devices(user_group=user_group)
         if (plans_allowed_uid != self._current_plans_allowed_uid) or (
             user_group not in self._current_plans_allowed
         ):
@@ -444,7 +444,7 @@ class API_Async_Mixin(API_Base):
         # Docstring is maintained separately
         status = await self._status(reload=reload)
         devices_allowed_uid = status["devices_allowed_uid"]
-        user_group = self._get_user_group_for_allowed_plans_devices(user_group)
+        user_group = self._get_user_group_for_allowed_plans_devices(user_group=user_group)
         if (devices_allowed_uid != self._current_devices_allowed_uid) or (
             user_group not in self._current_devices_allowed
         ):

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -497,9 +497,11 @@ class API_Async_Mixin(API_Base):
         self._clear_status_timestamp()
         return await self.send_request(method="script_upload", params=request_params)
 
-    async def function_execute(self, item, *, run_in_background=None):
+    async def function_execute(self, item, *, run_in_background=None, user=None, user_group=None):
         # Docstring is maintained separately
-        request_params = self._prepare_function_execute(item=item, run_in_background=run_in_background)
+        request_params = self._prepare_function_execute(
+            item=item, run_in_background=run_in_background, user=user, user_group=user_group
+        )
         self._clear_status_timestamp()
         return await self.send_request(method="function_execute", params=request_params)
 

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -429,24 +429,30 @@ class API_Async_Mixin(API_Base):
         # Docstring is maintained separately
         status = await self._status(reload=reload)
         plans_allowed_uid = status["plans_allowed_uid"]
-        if plans_allowed_uid != self._current_plans_allowed_uid:
+        user_group = self._get_user_group_for_allowed_plans_devices(user_group)
+        if (plans_allowed_uid != self._current_plans_allowed_uid) or (
+            user_group not in self._current_plans_allowed
+        ):
             request_params = self._prepare_plans_devices_allowed(user_group=user_group)
             response = await self.send_request(method="plans_allowed", params=request_params)
-            self._process_response_plans_allowed(response)
+            self._process_response_plans_allowed(response, user_group=user_group)
         else:
-            response = self._generate_response_plans_allowed()
+            response = self._generate_response_plans_allowed(user_group=user_group)
         return response
 
     async def devices_allowed(self, *, reload=False, user_group=None):
         # Docstring is maintained separately
         status = await self._status(reload=reload)
         devices_allowed_uid = status["devices_allowed_uid"]
-        if devices_allowed_uid != self._current_devices_allowed_uid:
+        user_group = self._get_user_group_for_allowed_plans_devices(user_group)
+        if (devices_allowed_uid != self._current_devices_allowed_uid) or (
+            user_group not in self._current_devices_allowed
+        ):
             request_params = self._prepare_plans_devices_allowed(user_group=user_group)
             response = await self.send_request(method="devices_allowed", params=request_params)
-            self._process_response_devices_allowed(response)
+            self._process_response_devices_allowed(response, user_group=user_group)
         else:
-            response = self._generate_response_devices_allowed()
+            response = self._generate_response_devices_allowed(user_group=user_group)
         return response
 
     async def plans_existing(self, *, reload=False):

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -300,16 +300,20 @@ class API_Async_Mixin(API_Base):
     # =====================================================================================
     #                 API for monitoring and control of Queue
 
-    async def item_add(self, item, *, pos=None, before_uid=None, after_uid=None):
+    async def item_add(self, item, *, pos=None, before_uid=None, after_uid=None, user=None, user_group=None):
         # Docstring is maintained separately
-        request_params = self._prepare_item_add(item=item, pos=pos, before_uid=before_uid, after_uid=after_uid)
+        request_params = self._prepare_item_add(
+            item=item, pos=pos, before_uid=before_uid, after_uid=after_uid, user=user, user_group=user_group
+        )
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_add", params=request_params)
 
-    async def item_add_batch(self, items, *, pos=None, before_uid=None, after_uid=None):
+    async def item_add_batch(
+        self, items, *, pos=None, before_uid=None, after_uid=None, user=None, user_group=None
+    ):
         # Docstring is maintained separately
         request_params = self._prepare_item_add_batch(
-            items=items, pos=pos, before_uid=before_uid, after_uid=after_uid
+            items=items, pos=pos, before_uid=before_uid, after_uid=after_uid, user=user, user_group=user_group
         )
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_add_batch", params=request_params)
@@ -421,24 +425,24 @@ class API_Async_Mixin(API_Base):
         self._clear_status_timestamp()
         return await self.send_request(method="history_clear")
 
-    async def plans_allowed(self, *, reload=False):
+    async def plans_allowed(self, *, reload=False, user_group=None):
         # Docstring is maintained separately
         status = await self._status(reload=reload)
         plans_allowed_uid = status["plans_allowed_uid"]
         if plans_allowed_uid != self._current_plans_allowed_uid:
-            request_params = self._prepare_plans_devices_allowed()
+            request_params = self._prepare_plans_devices_allowed(user_group=user_group)
             response = await self.send_request(method="plans_allowed", params=request_params)
             self._process_response_plans_allowed(response)
         else:
             response = self._generate_response_plans_allowed()
         return response
 
-    async def devices_allowed(self, *, reload=False):
+    async def devices_allowed(self, *, reload=False, user_group=None):
         # Docstring is maintained separately
         status = await self._status(reload=reload)
         devices_allowed_uid = status["devices_allowed_uid"]
         if devices_allowed_uid != self._current_devices_allowed_uid:
-            request_params = self._prepare_plans_devices_allowed()
+            request_params = self._prepare_plans_devices_allowed(user_group=user_group)
             response = await self.send_request(method="devices_allowed", params=request_params)
             self._process_response_devices_allowed(response)
         else:

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -318,9 +318,9 @@ class API_Async_Mixin(API_Base):
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_add_batch", params=request_params)
 
-    async def item_update(self, item, *, replace=None):
+    async def item_update(self, item, *, replace=None, user=None, user_group=None):
         # Docstring is maintained separately
-        request_params = self._prepare_item_update(item=item, replace=replace)
+        request_params = self._prepare_item_update(item=item, replace=replace, user=user, user_group=user_group)
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_update", params=request_params)
 
@@ -358,9 +358,9 @@ class API_Async_Mixin(API_Base):
         request_params = self._prepare_item_get_remove(pos=pos, uid=uid)
         return await self.send_request(method="queue_item_get", params=request_params)
 
-    async def item_execute(self, item):
+    async def item_execute(self, item, *, user=None, user_group=None):
         # Docstring is maintained separately
-        request_params = self._prepare_item_execute(item=item)
+        request_params = self._prepare_item_execute(item=item, user=user, user_group=user_group)
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_execute", params=request_params)
 

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -240,10 +240,10 @@ class API_Base:
         """
         self._status_timestamp = None
 
-    def _request_params_add_user_info(self, request_params):
+    def _request_params_add_user_info(self, request_params, *, user=None, user_group=None):
         if self._pass_user_info:
-            request_params["user"] = self._user
-            request_params["user_group"] = self._user_group
+            request_params["user"] = user if user else self._user
+            request_params["user_group"] = user_group if user_group else self._user_group
 
     def _add_request_param(self, request_params, name, value):
         """
@@ -252,7 +252,7 @@ class API_Base:
         if value is not None:
             request_params[name] = value
 
-    def _prepare_item_add(self, *, item, pos, before_uid, after_uid):
+    def _prepare_item_add(self, *, item, pos, before_uid, after_uid, user=None, user_group=None):
         """
         Prepare parameters for ``item_add`` operation.
         """
@@ -265,10 +265,10 @@ class API_Base:
         self._add_request_param(request_params, "pos", pos)
         self._add_request_param(request_params, "before_uid", before_uid)
         self._add_request_param(request_params, "after_uid", after_uid)
-        self._request_params_add_user_info(request_params)
+        self._request_params_add_user_info(request_params, user=user, user_group=user_group)
         return request_params
 
-    def _prepare_item_add_batch(self, *, items, pos, before_uid, after_uid):
+    def _prepare_item_add_batch(self, *, items, pos, before_uid, after_uid, user=None, user_group=None):
         """
         Prepare parameters for ``item_add_batch`` operation.
         """
@@ -287,7 +287,7 @@ class API_Base:
         self._add_request_param(request_params, "pos", pos)
         self._add_request_param(request_params, "before_uid", before_uid)
         self._add_request_param(request_params, "after_uid", after_uid)
-        self._request_params_add_user_info(request_params)
+        self._request_params_add_user_info(request_params, user=user, user_group=user_group)
         return request_params
 
     def _prepare_item_update(self, *, item, replace):
@@ -412,12 +412,12 @@ class API_Base:
         }
         return response
 
-    def _prepare_plans_devices_allowed(self):
+    def _prepare_plans_devices_allowed(self, *, user_group):
         """
         Prepare parameters for ``plans_allowed`` and ``devices_allowed`` operation.
         """
         request_params = {}
-        self._request_params_add_user_info(request_params)
+        self._request_params_add_user_info(request_params, user_group=user_group)
 
         # User name should not be includedin the request
         if "user" in request_params:

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -187,6 +187,41 @@ class API_Base:
         self._current_run_list = []
         self._current_run_list_uid = None
 
+    def _check_name(self, name, name_in_msg):
+        if not isinstance(name, str):
+            raise ValueError(f"{name_in_msg} {name!r} is not a string: type {type(name)!r}")
+        if not name:
+            raise ValueError(f"{name_in_msg} is an empty string.")
+
+    @property
+    def user(self):
+        """
+        Get and set the default user name. The default value is used if user name is not passed
+        explicitly as an API parameter (for API calls that require user name). User name is ignored
+        in HTTP API requests, since HTTP server is expected to manager user names.
+        """
+        return self._user
+
+    @user.setter
+    def user(self, user):
+        self._check_name(user, "User name")
+        self._user = user
+
+    @property
+    def user_group(self):
+        """
+        Get and set the default user group name. The default value is used if the group name is
+        not passed explicitly as an API parameter (for API calls that require user group name).
+        The group name is ignored in HTTP API requests, since HTTP server is expected to manage
+        user information including group names.
+        """
+        return self._user_group
+
+    @user_group.setter
+    def user_group(self, user_group):
+        self._check_name(user_group, "User group name")
+        self._user_group = user_group
+
     def _clear_status_timestamp(self):
         """
         Clearing status timestamp causes status to be reloaded from the server next time it is requested.

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -290,7 +290,7 @@ class API_Base:
         self._request_params_add_user_info(request_params, user=user, user_group=user_group)
         return request_params
 
-    def _prepare_item_update(self, *, item, replace):
+    def _prepare_item_update(self, *, item, replace, user=None, user_group=None):
         """
         Prepare parameters for ``item_update`` operation.
         """
@@ -301,7 +301,7 @@ class API_Base:
 
         request_params = {"item": item}
         self._add_request_param(request_params, "replace", replace)
-        self._request_params_add_user_info(request_params)
+        self._request_params_add_user_info(request_params, user=user, user_group=user_group)
         return request_params
 
     def _prepare_item_move(self, *, pos, uid, pos_dest, before_uid, after_uid):
@@ -347,7 +347,7 @@ class API_Base:
         self._add_request_param(request_params, "ignore_missing", ignore_missing)
         return request_params
 
-    def _prepare_item_execute(self, *, item):
+    def _prepare_item_execute(self, *, item, user=None, user_group=None):
         """
         Prepare parameters for ``item_execute`` operation.
         """
@@ -357,7 +357,7 @@ class API_Base:
         item = item.to_dict() if isinstance(item, BItem) else dict(item).copy()
 
         request_params = {"item": item}
-        self._request_params_add_user_info(request_params)
+        self._request_params_add_user_info(request_params, user=user, user_group=user_group)
         return request_params
 
     def _prepare_queue_mode_set(self, **kwargs):

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -427,7 +427,7 @@ class API_Base:
         Prepare parameters for ``plans_allowed`` and ``devices_allowed`` operation.
         """
         request_params = {}
-        self._request_params_add_user_info(request_params, user_group=user_group)
+        self._request_params_add_user_info(request_params, user=None, user_group=user_group)
 
         # User name should not be includedin the request
         if "user" in request_params:

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -1,6 +1,8 @@
-from .item import BItem
 from collections.abc import Mapping, Iterable
 import copy
+import getpass
+
+from .item import BItem
 
 
 class WaitTimeoutError(TimeoutError):
@@ -170,6 +172,7 @@ class API_Base:
 
         self._user = "Python API User"
         self._user_group = "admin"
+        self.set_user_to_login_user_name()
 
         self._current_plan_queue = []
         self._current_running_item = {}
@@ -221,6 +224,15 @@ class API_Base:
     def user_group(self, user_group):
         self._check_name(user_group, "User group name")
         self._user_group = user_group
+
+    def set_user_to_login_user_name(self):
+        """
+        Set the default user name to 'login name' of the current user of the workstation. This function
+        is called during instantiation of ``REManagerAPI``, but it may be called manually at any time.
+        The name can be changed using ``REManagerAPI.user`` property. The default name is ignored by
+        HTTP version of the API.
+        """
+        self.user = getpass.getuser()
 
     def _clear_status_timestamp(self):
         """

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -170,9 +170,8 @@ class API_Base:
         self._status_current = None
         self._status_exception = None
 
-        self._user = "Python API User"
+        self._user = "Queue Server API User"  # Meaningful user name should be set in application code.
         self._user_group = "admin"
-        self.set_user_to_login_user_name()
 
         self._current_plan_queue = []
         self._current_running_item = {}
@@ -201,7 +200,7 @@ class API_Base:
         """
         Get and set the default user name. The default value is used if user name is not passed
         explicitly as an API parameter (for API calls that require user name). User name is ignored
-        in HTTP API requests, since HTTP server is expected to manager user names.
+        by the HTTP version of API, since HTTP server is expected to manage user names.
         """
         return self._user
 
@@ -215,8 +214,8 @@ class API_Base:
         """
         Get and set the default user group name. The default value is used if the group name is
         not passed explicitly as an API parameter (for API calls that require user group name).
-        The group name is ignored in HTTP API requests, since HTTP server is expected to manage
-        user information including group names.
+        The group name is ignored by the HTTP version of API, since HTTP server is expected to manage
+        user information including names of user group.
         """
         return self._user_group
 
@@ -225,12 +224,10 @@ class API_Base:
         self._check_name(user_group, "User group name")
         self._user_group = user_group
 
-    def set_user_to_login_user_name(self):
+    def set_user_name_to_login_name(self):
         """
-        Set the default user name to 'login name' of the current user of the workstation. This function
-        is called during instantiation of ``REManagerAPI``, but it may be called manually at any time.
-        The name can be changed using ``REManagerAPI.user`` property. The default name is ignored by
-        HTTP version of the API.
+        Set the default user name to 'login name'. Login name the current user of the workstation
+        is used. User name is ignored by the HTTP version of the API.
         """
         self.user = getpass.getuser()
 

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -240,7 +240,7 @@ class API_Base:
         """
         self._status_timestamp = None
 
-    def _request_params_add_user_info(self, request_params, *, user=None, user_group=None):
+    def _request_params_add_user_info(self, request_params, *, user, user_group):
         if self._pass_user_info:
             request_params["user"] = user if user else self._user
             request_params["user_group"] = user_group if user_group else self._user_group
@@ -252,7 +252,7 @@ class API_Base:
         if value is not None:
             request_params[name] = value
 
-    def _prepare_item_add(self, *, item, pos, before_uid, after_uid, user=None, user_group=None):
+    def _prepare_item_add(self, *, item, pos, before_uid, after_uid, user, user_group):
         """
         Prepare parameters for ``item_add`` operation.
         """
@@ -268,7 +268,7 @@ class API_Base:
         self._request_params_add_user_info(request_params, user=user, user_group=user_group)
         return request_params
 
-    def _prepare_item_add_batch(self, *, items, pos, before_uid, after_uid, user=None, user_group=None):
+    def _prepare_item_add_batch(self, *, items, pos, before_uid, after_uid, user, user_group):
         """
         Prepare parameters for ``item_add_batch`` operation.
         """
@@ -290,7 +290,7 @@ class API_Base:
         self._request_params_add_user_info(request_params, user=user, user_group=user_group)
         return request_params
 
-    def _prepare_item_update(self, *, item, replace, user=None, user_group=None):
+    def _prepare_item_update(self, *, item, replace, user, user_group):
         """
         Prepare parameters for ``item_update`` operation.
         """
@@ -347,7 +347,7 @@ class API_Base:
         self._add_request_param(request_params, "ignore_missing", ignore_missing)
         return request_params
 
-    def _prepare_item_execute(self, *, item, user=None, user_group=None):
+    def _prepare_item_execute(self, *, item, user, user_group):
         """
         Prepare parameters for ``item_execute`` operation.
         """
@@ -530,7 +530,7 @@ class API_Base:
         self._add_request_param(request_params, "run_in_background", run_in_background)
         return request_params
 
-    def _prepare_function_execute(self, *, item, run_in_background):
+    def _prepare_function_execute(self, *, item, run_in_background, user, user_group):
         """
         Prepare parameters for ``script_upload``
         """
@@ -541,7 +541,7 @@ class API_Base:
 
         request_params = {"item": item}
         self._add_request_param(request_params, "run_in_background", run_in_background)
-        self._request_params_add_user_info(request_params)
+        self._request_params_add_user_info(request_params, user=user, user_group=user_group)
         return request_params
 
     def _prepare_task_result(self, *, task_uid):

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -450,6 +450,12 @@ _doc_api_item_add = """
     before_uid, after_uid: str or None
         Insert the item before or after the item with the given item UID. If ``None``
         (default), then the parameters are not specified.
+    user, user_group: str or None (optional)
+        User name and user group name used in the API request. The parameter values 
+        override the default user and user group names (accessible using ``user`` and 
+        ``user_group`` properties). The default user or user group name is used 
+        if the respective parameter is not specified or ``None``. The parameters are 
+        ignored by the HTTP version of the API.
 
     Returns
     -------
@@ -540,6 +546,12 @@ _doc_api_item_add_batch = """
     before_uid, after_uid: str or None
         Insert the batch before or after the item with the given item UID. If ``None``
         (default), then the parameters are not specified.
+    user, user_group: str or None (optional)
+        User name and user group name used in the API request. The parameter values 
+        override the default user and user group names (accessible using ``user`` and 
+        ``user_group`` properties). The default user or user group name is used 
+        if the respective parameter is not specified or ``None``. The parameters are 
+        ignored by the HTTP version of the API.
 
     Returns
     -------
@@ -601,6 +613,12 @@ _doc_api_item_update = """
     replace: boolean
         The server generates a new item UID before the item is inserted in the queue
         if ``True``. Default: ``False``.
+    user, user_group: str or None (optional)
+        User name and user group name used in the API request. The parameter values 
+        override the default user and user group names (accessible using ``user`` and 
+        ``user_group`` properties). The default user or user group name is used 
+        if the respective parameter is not specified or ``None``. The parameters are 
+        ignored by the HTTP version of the API.
 
     Returns
     -------
@@ -934,6 +952,12 @@ _doc_api_item_execute = """
     item: dict, BItem, BPlan or BInst
         Dictionary of item parameters or an instance of ``BItem``, ``BPlan`` or ``BInst``
         representing a plan or an instruction.
+    user, user_group: str or None (optional)
+        User name and user group name used in the API request. The parameter values 
+        override the default user and user group names (accessible using ``user`` and 
+        ``user_group`` properties). The default user or user group name is used 
+        if the respective parameter is not specified or ``None``. The parameters are 
+        ignored by the HTTP version of the API.
 
     Returns
     -------
@@ -1299,6 +1323,12 @@ _doc_api_plans_allowed = """
         Set the parameter ``True`` to force reloading of status from the server before
         ``plans_allowed_uid`` is checked. Otherwise cached status is used.
 
+    user_group: str or None (optional)
+        User group name used in API request. Specified user group name overrides the default
+        user group name (accessible using ``user_group`` property). The default user group
+        name is used if the parameter is not specified or ``None``. The parameter is ignored
+        by the HTTP version of the API.
+
     Returns
     -------
     response: dict
@@ -1343,6 +1373,12 @@ _doc_api_devices_allowed = """
     reload: boolean
         Set the parameter ``True`` to force reloading of status from the server before
         ``devices_allowed_uid`` is checked. Otherwise cached status is used.
+
+    user_group: str or None (optional)
+        User group name used in API request. Specified user group name overrides the default
+        user group name (accessible using ``user_group`` property). The default user group
+        name is used if the parameter is not specified or ``None``. The parameter is ignored
+        by the HTTP version of the API.
 
     Returns
     -------
@@ -1807,6 +1843,12 @@ _doc_api_function_execute = """
         are executed in separate threads and only thread-safe scripts should be uploaded
         in the background. **Developers of data acquisition workflows and/or user specific
         code are responsible for thread safety.**
+    user, user_group: str or None (optional)
+        User name and user group name used in the API request. The parameter values 
+        override the default user and user group names (accessible using ``user`` and 
+        ``user_group`` properties). The default user or user group name is used 
+        if the respective parameter is not specified or ``None``. The parameters are 
+        ignored by the HTTP version of the API.
 
     Returns
     -------

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -451,10 +451,10 @@ _doc_api_item_add = """
         Insert the item before or after the item with the given item UID. If ``None``
         (default), then the parameters are not specified.
     user, user_group: str or None (optional)
-        User name and user group name used in the API request. The parameter values 
-        override the default user and user group names (accessible using ``user`` and 
-        ``user_group`` properties). The default user or user group name is used 
-        if the respective parameter is not specified or ``None``. The parameters are 
+        User name and user group name used in the API request. The parameter values
+        override the default user and user group names (accessible using ``user`` and
+        ``user_group`` properties). The default user or user group name is used
+        if the respective parameter is not specified or ``None``. The parameters are
         ignored by the HTTP version of the API.
 
     Returns
@@ -547,10 +547,10 @@ _doc_api_item_add_batch = """
         Insert the batch before or after the item with the given item UID. If ``None``
         (default), then the parameters are not specified.
     user, user_group: str or None (optional)
-        User name and user group name used in the API request. The parameter values 
-        override the default user and user group names (accessible using ``user`` and 
-        ``user_group`` properties). The default user or user group name is used 
-        if the respective parameter is not specified or ``None``. The parameters are 
+        User name and user group name used in the API request. The parameter values
+        override the default user and user group names (accessible using ``user`` and
+        ``user_group`` properties). The default user or user group name is used
+        if the respective parameter is not specified or ``None``. The parameters are
         ignored by the HTTP version of the API.
 
     Returns
@@ -614,10 +614,10 @@ _doc_api_item_update = """
         The server generates a new item UID before the item is inserted in the queue
         if ``True``. Default: ``False``.
     user, user_group: str or None (optional)
-        User name and user group name used in the API request. The parameter values 
-        override the default user and user group names (accessible using ``user`` and 
-        ``user_group`` properties). The default user or user group name is used 
-        if the respective parameter is not specified or ``None``. The parameters are 
+        User name and user group name used in the API request. The parameter values
+        override the default user and user group names (accessible using ``user`` and
+        ``user_group`` properties). The default user or user group name is used
+        if the respective parameter is not specified or ``None``. The parameters are
         ignored by the HTTP version of the API.
 
     Returns
@@ -953,10 +953,10 @@ _doc_api_item_execute = """
         Dictionary of item parameters or an instance of ``BItem``, ``BPlan`` or ``BInst``
         representing a plan or an instruction.
     user, user_group: str or None (optional)
-        User name and user group name used in the API request. The parameter values 
-        override the default user and user group names (accessible using ``user`` and 
-        ``user_group`` properties). The default user or user group name is used 
-        if the respective parameter is not specified or ``None``. The parameters are 
+        User name and user group name used in the API request. The parameter values
+        override the default user and user group names (accessible using ``user`` and
+        ``user_group`` properties). The default user or user group name is used
+        if the respective parameter is not specified or ``None``. The parameters are
         ignored by the HTTP version of the API.
 
     Returns
@@ -1844,10 +1844,10 @@ _doc_api_function_execute = """
         in the background. **Developers of data acquisition workflows and/or user specific
         code are responsible for thread safety.**
     user, user_group: str or None (optional)
-        User name and user group name used in the API request. The parameter values 
-        override the default user and user group names (accessible using ``user`` and 
-        ``user_group`` properties). The default user or user group name is used 
-        if the respective parameter is not specified or ``None``. The parameters are 
+        User name and user group name used in the API request. The parameter values
+        override the default user and user group names (accessible using ``user`` and
+        ``user_group`` properties). The default user or user group name is used
+        if the respective parameter is not specified or ``None``. The parameters are
         ignored by the HTTP version of the API.
 
     Returns

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -496,9 +496,11 @@ class API_Threads_Mixin(API_Base):
         self._clear_status_timestamp()
         return self.send_request(method="script_upload", params=request_params)
 
-    def function_execute(self, item, *, run_in_background=None):
+    def function_execute(self, item, *, run_in_background=None, user=None, user_group=None):
         # Docstring is maintained separately
-        request_params = self._prepare_function_execute(item=item, run_in_background=run_in_background)
+        request_params = self._prepare_function_execute(
+            item=item, run_in_background=run_in_background, user=user, user_group=user_group
+        )
         self._clear_status_timestamp()
         return self.send_request(method="function_execute", params=request_params)
 

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -428,7 +428,7 @@ class API_Threads_Mixin(API_Base):
         # Docstring is maintained separately
         status = self._status(reload=reload)
         plans_allowed_uid = status["plans_allowed_uid"]
-        user_group = self._get_user_group_for_allowed_plans_devices(user_group)
+        user_group = self._get_user_group_for_allowed_plans_devices(user_group=user_group)
         if (plans_allowed_uid != self._current_plans_allowed_uid) or (
             user_group not in self._current_plans_allowed
         ):
@@ -443,7 +443,7 @@ class API_Threads_Mixin(API_Base):
         # Docstring is maintained separately
         status = self._status(reload=reload)
         devices_allowed_uid = status["devices_allowed_uid"]
-        user_group = self._get_user_group_for_allowed_plans_devices(user_group)
+        user_group = self._get_user_group_for_allowed_plans_devices(user_group=user_group)
         if (devices_allowed_uid != self._current_devices_allowed_uid) or (
             user_group not in self._current_devices_allowed
         ):

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -294,16 +294,18 @@ class API_Threads_Mixin(API_Base):
     # =====================================================================================
     #                 API for monitoring and control of Queue
 
-    def item_add(self, item, *, pos=None, before_uid=None, after_uid=None):
+    def item_add(self, item, *, pos=None, before_uid=None, after_uid=None, user=None, user_group=None):
         # Docstring is maintained separately
-        request_params = self._prepare_item_add(item=item, pos=pos, before_uid=before_uid, after_uid=after_uid)
+        request_params = self._prepare_item_add(
+            item=item, pos=pos, before_uid=before_uid, after_uid=after_uid, user=user, user_group=user_group
+        )
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_add", params=request_params)
 
-    def item_add_batch(self, items, *, pos=None, before_uid=None, after_uid=None):
+    def item_add_batch(self, items, *, pos=None, before_uid=None, after_uid=None, user=None, user_group=None):
         # Docstring is maintained separately
         request_params = self._prepare_item_add_batch(
-            items=items, pos=pos, before_uid=before_uid, after_uid=after_uid
+            items=items, pos=pos, before_uid=before_uid, after_uid=after_uid, user=user, user_group=user_group
         )
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_add_batch", params=request_params)
@@ -422,24 +424,24 @@ class API_Threads_Mixin(API_Base):
         self._clear_status_timestamp()
         return self.send_request(method="history_clear")
 
-    def plans_allowed(self, *, reload=False):
+    def plans_allowed(self, *, reload=False, user_group=None):
         # Docstring is maintained separately
         status = self._status(reload=reload)
         plans_allowed_uid = status["plans_allowed_uid"]
         if plans_allowed_uid != self._current_plans_allowed_uid:
-            request_params = self._prepare_plans_devices_allowed()
+            request_params = self._prepare_plans_devices_allowed(user_group=user_group)
             response = self.send_request(method="plans_allowed", params=request_params)
             self._process_response_plans_allowed(response)
         else:
             response = self._generate_response_plans_allowed()
         return response
 
-    def devices_allowed(self, *, reload=False):
+    def devices_allowed(self, *, reload=False, user_group=None):
         # Docstring is maintained separately
         status = self._status(reload=reload)
         devices_allowed_uid = status["devices_allowed_uid"]
         if devices_allowed_uid != self._current_devices_allowed_uid:
-            request_params = self._prepare_plans_devices_allowed()
+            request_params = self._prepare_plans_devices_allowed(user_group=user_group)
             response = self.send_request(method="devices_allowed", params=request_params)
             self._process_response_devices_allowed(response)
         else:

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -428,24 +428,30 @@ class API_Threads_Mixin(API_Base):
         # Docstring is maintained separately
         status = self._status(reload=reload)
         plans_allowed_uid = status["plans_allowed_uid"]
-        if plans_allowed_uid != self._current_plans_allowed_uid:
+        user_group = self._get_user_group_for_allowed_plans_devices(user_group)
+        if (plans_allowed_uid != self._current_plans_allowed_uid) or (
+            user_group not in self._current_plans_allowed
+        ):
             request_params = self._prepare_plans_devices_allowed(user_group=user_group)
             response = self.send_request(method="plans_allowed", params=request_params)
-            self._process_response_plans_allowed(response)
+            self._process_response_plans_allowed(response, user_group=user_group)
         else:
-            response = self._generate_response_plans_allowed()
+            response = self._generate_response_plans_allowed(user_group=user_group)
         return response
 
     def devices_allowed(self, *, reload=False, user_group=None):
         # Docstring is maintained separately
         status = self._status(reload=reload)
         devices_allowed_uid = status["devices_allowed_uid"]
-        if devices_allowed_uid != self._current_devices_allowed_uid:
+        user_group = self._get_user_group_for_allowed_plans_devices(user_group)
+        if (devices_allowed_uid != self._current_devices_allowed_uid) or (
+            user_group not in self._current_devices_allowed
+        ):
             request_params = self._prepare_plans_devices_allowed(user_group=user_group)
             response = self.send_request(method="devices_allowed", params=request_params)
-            self._process_response_devices_allowed(response)
+            self._process_response_devices_allowed(response, user_group=user_group)
         else:
-            response = self._generate_response_devices_allowed()
+            response = self._generate_response_devices_allowed(user_group=user_group)
         return response
 
     def plans_existing(self, *, reload=False):

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -310,9 +310,9 @@ class API_Threads_Mixin(API_Base):
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_add_batch", params=request_params)
 
-    def item_update(self, item, *, replace=None):
+    def item_update(self, item, *, replace=None, user=None, user_group=None):
         # Docstring is maintained separately
-        request_params = self._prepare_item_update(item=item, replace=replace)
+        request_params = self._prepare_item_update(item=item, replace=replace, user=user, user_group=user_group)
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_update", params=request_params)
 
@@ -350,9 +350,9 @@ class API_Threads_Mixin(API_Base):
         request_params = self._prepare_item_get_remove(pos=pos, uid=uid)
         return self.send_request(method="queue_item_get", params=request_params)
 
-    def item_execute(self, item):
+    def item_execute(self, item, *, user=None, user_group=None):
         # Docstring is maintained separately
-        request_params = self._prepare_item_execute(item=item)
+        request_params = self._prepare_item_execute(item=item, user=user, user_group=user_group)
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_execute", params=request_params)
 

--- a/bluesky_queueserver_api/comm_base.py
+++ b/bluesky_queueserver_api/comm_base.py
@@ -104,9 +104,10 @@ class ReManagerAPI_Base:
     def __init__(self, *, request_fail_exceptions=True):
         # Raise exceptions if request fails (success=False)
         self._request_fail_exceptions = request_fail_exceptions
-        self._pass_user_info = True
         self._console_monitor = None
+
         self._protocol = None
+        self._pass_user_info = True
 
     @property
     def request_fail_exceptions_enabled(self):
@@ -225,13 +226,12 @@ class ReManagerAPI_HTTP_Base(ReManagerAPI_Base):
         super().__init__(request_fail_exceptions=request_fail_exceptions)
 
         self._protocol = self.Protocols.HTTP
-
-        http_server_uri = http_server_uri or os.environ.get("QSERVER_HTTP_SERVER_URI")
-        http_server_uri = http_server_uri or default_http_server_uri
-
         # Do not pass user info with request (e.g. user info is not required in REST API requests,
         #   because HTTP Server assigns user name and user group based on login information)
         self._pass_user_info = False
+
+        http_server_uri = http_server_uri or os.environ.get("QSERVER_HTTP_SERVER_URI")
+        http_server_uri = http_server_uri or default_http_server_uri
 
         self._timeout = timeout
         self._request_fail_exceptions = request_fail_exceptions

--- a/bluesky_queueserver_api/comm_base.py
+++ b/bluesky_queueserver_api/comm_base.py
@@ -149,6 +149,10 @@ class ReManagerAPI_Base:
 
     @property
     def protocol(self):
+        """
+        Indicates the protocol used for communication (ZMQ or HTTP). The returned value is of
+        ``REManagerAPI.Protocols`` enum type.
+        """
         if self._protocol is None:
             raise ValueError("Protocol is not defined")
         return self._protocol

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -2446,13 +2446,13 @@ def test_console_monitor_05(
 
             RM.console_monitor.enable()
             assert RM.console_monitor.enabled is True
-            asyncio.sleep(1)
+            await asyncio.sleep(1)
 
             await RM.environment_open()
             await RM.wait_for_idle(timeout=10)
 
             await RM.script_upload(script)
-            asyncio.sleep(2)
+            await asyncio.sleep(2)
             await RM.wait_for_idle(timeout=10)
 
             text = await RM.console_monitor.text()
@@ -2545,7 +2545,7 @@ def test_console_monitor_06(re_manager_cmd, fastapi_server, library, protocol, n
 
             RM.console_monitor.enable()
             assert RM.console_monitor.enabled is True
-            asyncio.sleep(1)
+            await asyncio.sleep(1)
 
             check_resp(await RM.item_add(BPlan("plan_test_progress_bars", n_progress_bars)))
             check_status(await RM.status(), "idle", 1)
@@ -2650,7 +2650,7 @@ def test_console_monitor_07(
 
             RM.console_monitor.enable()
             assert RM.console_monitor.enabled is True
-            asyncio.sleep(1)
+            await asyncio.sleep(1)
 
             check_resp(await RM.environment_open())
             await RM.wait_for_idle(timeout=10)
@@ -2759,7 +2759,7 @@ def test_console_monitor_08(re_manager_cmd, fastapi_server, library, protocol): 
 
             RM.console_monitor.enable()
             assert RM.console_monitor.enabled is True
-            asyncio.sleep(1)
+            await asyncio.sleep(1)
             text_uid0 = RM.console_monitor.text_uid
 
             # Generate some console output
@@ -2767,7 +2767,7 @@ def test_console_monitor_08(re_manager_cmd, fastapi_server, library, protocol): 
             await RM.wait_for_idle(timeout=10)
             check_resp(await RM.environment_close())
             await RM.wait_for_idle(timeout=10)
-            asyncio.sleep(1)
+            await asyncio.sleep(1)
 
             text_uid1 = RM.console_monitor.text_uid
             text1 = await RM.console_monitor.text()

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -20,15 +20,20 @@ _plan1 = {"name": "count", "args": [["det1", "det2"]], "item_type": "plan"}
 # fmt: on
 def test_instantiation_01(re_manager, fastapi_server, protocol, library):  # noqa: F811
     """
-    ``REManagerAPI``: instantiation of classes
+    ``REManagerAPI``: instantiation of classes. Check if ``set_user_name_to_login_name`` works as expected.
     """
     rm_api_class = _select_re_manager_api(protocol, library)
-    user_name = getpass.getuser()
+    user_name = "Queue Server API User"
+    user_name_2 = getpass.getuser()
     if not _is_async(library):
         RM = rm_api_class()
         assert RM.protocol == RM.Protocols(protocol)
         assert RM.user == user_name
         assert RM.user_group == "admin"
+
+        RM.set_user_name_to_login_name()
+        assert RM.user == user_name_2
+
         RM.close()
     else:
 
@@ -37,6 +42,10 @@ def test_instantiation_01(re_manager, fastapi_server, protocol, library):  # noq
             assert RM.protocol == RM.Protocols(protocol)
             assert RM.user == user_name
             assert RM.user_group == "admin"
+
+            RM.set_user_name_to_login_name()
+            assert RM.user == user_name_2
+
             await RM.close()
 
         asyncio.run(testing())

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -1410,6 +1410,126 @@ def test_plans_devices_allowed_01(re_manager, fastapi_server, protocol, library)
 @pytest.mark.parametrize("library", ["THREADS", "ASYNC"])
 @pytest.mark.parametrize("protocol", ["ZMQ", "HTTP"])
 # fmt: on
+def test_plans_devices_allowed_02(re_manager, fastapi_server, protocol, library):  # noqa: F811
+    """
+    ``plans_allowed``, ``devices_allowed``: test that the API can handle 'user_group' optional parameter.
+    """
+    rm_api_class = _select_re_manager_api(protocol, library)
+
+    if not _is_async(library):
+        RM = rm_api_class()
+
+        response = RM.plans_allowed(user_group=None)
+        assert response["success"] is True
+        plans_allowed = response["plans_allowed"]
+        assert len(plans_allowed) > 0
+
+        response2 = RM.plans_allowed(user_group=RM.user_group)
+        assert response2["success"] is True
+        plans_allowed2 = response2["plans_allowed"]
+        assert plans_allowed2 == plans_allowed
+
+        response3 = RM.plans_allowed(user_group="test_user")
+        assert response3["success"] is True
+        plans_allowed3 = response3["plans_allowed"]
+        if protocol != "HTTP":
+            assert plans_allowed3 != plans_allowed
+            # Request is expected to fail for non-existing user group
+            with pytest.raises(RM.RequestFailedError):
+                RM.plans_allowed(user_group="non_existing_user_group")
+        else:
+            # Group name is managed by HTTP server. User group in parameters is ignored.
+            assert plans_allowed3 == plans_allowed
+            # Group name is ignored, so the request will succeed
+            RM.plans_allowed(user_group="non_existing_user_group")
+
+        response = RM.devices_allowed(user_group=None)
+        assert response["success"] is True
+        devices_allowed = response["devices_allowed"]
+        assert len(devices_allowed) > 0
+
+        response2 = RM.devices_allowed(user_group=RM.user_group)
+        assert response2["success"] is True
+        devices_allowed2 = response2["devices_allowed"]
+        assert devices_allowed2 == devices_allowed
+
+        response3 = RM.devices_allowed(user_group="test_user")
+        assert response3["success"] is True
+        devices_allowed3 = response3["devices_allowed"]
+        if protocol != "HTTP":
+            assert devices_allowed3 != devices_allowed
+            # Request is expected to fail for non-existing user group
+            with pytest.raises(RM.RequestFailedError):
+                RM.devices_allowed(user_group="non_existing_user_group")
+        else:
+            # Group name is managed by HTTP server. User group in parameters is ignored.
+            assert devices_allowed3 == devices_allowed
+            # Group name is ignored, so the request will succeed
+            RM.devices_allowed(user_group="non_existing_user_group")
+
+        RM.close()
+    else:
+
+        async def testing():
+            RM = rm_api_class()
+
+            response = await RM.plans_allowed(user_group=None)
+            assert response["success"] is True
+            plans_allowed = response["plans_allowed"]
+            assert len(plans_allowed) > 0
+
+            response2 = await RM.plans_allowed(user_group=RM.user_group)
+            assert response2["success"] is True
+            plans_allowed2 = response2["plans_allowed"]
+            assert plans_allowed2 == plans_allowed
+
+            response3 = await RM.plans_allowed(user_group="test_user")
+            assert response3["success"] is True
+            plans_allowed3 = response3["plans_allowed"]
+            if protocol != "HTTP":
+                assert plans_allowed3 != plans_allowed
+                # Request is expected to fail for non-existing user group
+                with pytest.raises(RM.RequestFailedError):
+                    await RM.plans_allowed(user_group="non_existing_user_group")
+            else:
+                # Group name is managed by HTTP server. User group in parameters is ignored.
+                assert plans_allowed3 == plans_allowed
+                # Group name is ignored, so the request will succeed
+                await RM.plans_allowed(user_group="non_existing_user_group")
+
+            response = await RM.devices_allowed(user_group=None)
+            assert response["success"] is True
+            devices_allowed = response["devices_allowed"]
+            assert len(devices_allowed) > 0
+
+            response2 = await RM.devices_allowed(user_group=RM.user_group)
+            assert response2["success"] is True
+            devices_allowed2 = response2["devices_allowed"]
+            assert devices_allowed2 == devices_allowed
+
+            response3 = await RM.devices_allowed(user_group="test_user")
+            assert response3["success"] is True
+            devices_allowed3 = response3["devices_allowed"]
+            if protocol != "HTTP":
+                assert devices_allowed3 != devices_allowed
+                # Request is expected to fail for non-existing user group
+                with pytest.raises(RM.RequestFailedError):
+                    await RM.devices_allowed(user_group="non_existing_user_group")
+            else:
+                # Group name is managed by HTTP server. User group in parameters is ignored.
+                assert devices_allowed3 == devices_allowed
+                # Group name is ignored, so the request will succeed
+                await RM.devices_allowed(user_group="non_existing_user_group")
+
+            await RM.close()
+
+        asyncio.run(testing())
+
+
+# fmt: off
+@pytest.mark.parametrize("library", ["THREADS", "ASYNC"])
+@pytest.mark.parametrize("protocol", ["ZMQ", "HTTP"])
+# fmt: on
 def test_plans_devices_existing_01(re_manager, fastapi_server, protocol, library):  # noqa: F811
     """
     ``plans_existing``, ``devices_existing``: basic tests

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -21,6 +21,7 @@ _plan1 = {"name": "count", "args": [["det1", "det2"]], "item_type": "plan"}
 def test_instantiation_01(re_manager, fastapi_server, protocol, library):  # noqa: F811
     """
     ``REManagerAPI``: instantiation of classes. Check if ``set_user_name_to_login_name`` works as expected.
+    Check that ``user`` and ``user_group`` properties work properly.
     """
     rm_api_class = _select_re_manager_api(protocol, library)
     user_name = "Queue Server API User"
@@ -34,6 +35,11 @@ def test_instantiation_01(re_manager, fastapi_server, protocol, library):  # noq
         RM.set_user_name_to_login_name()
         assert RM.user == user_name_2
 
+        RM.user = "TestUser"
+        RM.user_group = "TestUserGroup"
+        assert RM.user == "TestUser"
+        assert RM.user_group == "TestUserGroup"
+
         RM.close()
     else:
 
@@ -45,6 +51,11 @@ def test_instantiation_01(re_manager, fastapi_server, protocol, library):  # noq
 
             RM.set_user_name_to_login_name()
             assert RM.user == user_name_2
+
+            RM.user = "TestUser"
+            RM.user_group = "TestUserGroup"
+            assert RM.user == "TestUser"
+            assert RM.user_group == "TestUserGroup"
 
             await RM.close()
 

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -12,8 +12,6 @@ from .common import _is_async, _select_re_manager_api
 from bluesky_queueserver_api import BPlan, BFunc, WaitMonitor
 
 _plan1 = {"name": "count", "args": [["det1", "det2"]], "item_type": "plan"}
-_user = "Test User"
-_user_group = "admin"
 
 
 # fmt: off
@@ -66,6 +64,9 @@ def test_status_02(re_manager, fastapi_server, protocol, library, reload):  # no
     In a rapid sequence: read status, add item to queue (using low-level API), read status again.
     Verify if the status was reloaded if ``reload`` is ``True``.
     """
+
+    _user, _user_group = "Test User", "admin"
+    
     rm_api_class = _select_re_manager_api(protocol, library)
     status_params = {"reload": reload} if (reload is not None) else {}
     add_item_params = {"item": _plan1}

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -63,6 +63,17 @@ Synchronous Communication with 0MQ Server
     zmq.REManagerAPI
     zmq.REManagerAPI.close
 
+Configuration of REManagerAPI
+*****************************
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated
+
+    zmq.REManagerAPI.user
+    zmq.REManagerAPI.user_group
+    zmq.REManagerAPI.set_user_name_to_login_name
+
 Low-Level API
 *************
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -197,5 +197,5 @@ intersphinx_mapping = {
     'numpy': ('https://numpy.org/doc/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
-    'matplotlib': ('https://matplotlib.org/stable', None),
+    # 'matplotlib': ('https://matplotlib.org/stable', None),
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Extension of API to support multi-user applications, which can have multiple users logged into the system and simultaneously control or monitor RE Manager. The features will allow to include proper user name and user group information in the requests, cache and return lists of allowed plans and devices for multiple user groups.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The updated API will be required in further development of  `bluesky-httpserver`.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Read/write properties `REManagerAPI.user` and `REManagerAPI.user_group` for access to default user name and user group.
- New configuration API: `REManagerAPI.set_user_name_to_login_name()`. The API sets the default user name to login name of the workstation user.

### Changed

- The API functions that send user name and user group as part of request to the server are now accepting `user` and `user_group` parameters that override current default values. The API include `plans_allowed`, `devices_allowed`, `item_add`, `item_add_batch`, `item_update`, `item_execute`, `function_execute`. HTTP version of the API is not sending user name and user group to the server and values of `user` and `user_group` parameters are ignored.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests for new and updated features are implemented.

<!--
## Screenshots (if appropriate):
-->
