### PR TITLE
'script_upload' API: support for the new 'update_lists' parameter

### DIFF
--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -495,10 +495,10 @@ class API_Async_Mixin(API_Base):
         self._clear_status_timestamp()
         return await self.send_request(method="permissions_set", params=request_params)
 
-    async def script_upload(self, script, *, update_re=None, run_in_background=None):
+    async def script_upload(self, script, *, update_lists=None, update_re=None, run_in_background=None):
         # Docstring is maintained separately
         request_params = self._prepare_script_upload(
-            script=script, update_re=update_re, run_in_background=run_in_background
+            script=script, update_lists=update_lists, update_re=update_re, run_in_background=run_in_background
         )
         self._clear_status_timestamp()
         return await self.send_request(method="script_upload", params=request_params)

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -538,11 +538,12 @@ class API_Base:
         request_params = {"user_group_permissions": user_group_permissions}
         return request_params
 
-    def _prepare_script_upload(self, *, script, update_re, run_in_background):
+    def _prepare_script_upload(self, *, script, update_lists, update_re, run_in_background):
         """
         Prepare parameters for ``script_upload``
         """
         request_params = {"script": script}
+        self._add_request_param(request_params, "update_lists", update_lists)
         self._add_request_param(request_params, "update_re", update_re)
         self._add_request_param(request_params, "run_in_background", run_in_background)
         return request_params

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -1767,6 +1767,12 @@ _doc_api_script_upload = r"""
         The string that contains the Python script. The script should satisfy the same
         requirements as Bluesky startup scripts. The script can use objects already
         existing in the RE Worker namespace.
+    update_lists: boolean (optional, default True)
+        Update lists of existing and available plans and devices after execution of the script.
+        It is required to update the lists if the script adds or modifies plans and/or devices
+        in RE Worker namespace, otherwise it is more efficient to disable the update. For example,
+        the update could be disabled for the remotely executed scripts that print or modify 
+        variables from the namespace during iteractive debug session.
     update_re: boolean (optional, default False)
         The uploaded scripts may replace Run Engine (``RE``) and Data Broker (``db``)
         instances in the namespace. In most cases this operation should not be allowed,

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -1771,7 +1771,7 @@ _doc_api_script_upload = r"""
         Update lists of existing and available plans and devices after execution of the script.
         It is required to update the lists if the script adds or modifies plans and/or devices
         in RE Worker namespace, otherwise it is more efficient to disable the update. For example,
-        the update could be disabled for the remotely executed scripts that print or modify 
+        the update could be disabled for the remotely executed scripts that print or modify
         variables from the namespace during iteractive debug session.
     update_re: boolean (optional, default False)
         The uploaded scripts may replace Run Engine (``RE``) and Data Broker (``db``)

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -494,10 +494,10 @@ class API_Threads_Mixin(API_Base):
         self._clear_status_timestamp()
         return self.send_request(method="permissions_set", params=request_params)
 
-    def script_upload(self, script, *, update_re=None, run_in_background=None):
+    def script_upload(self, script, *, update_lists=None, update_re=None, run_in_background=None):
         # Docstring is maintained separately
         request_params = self._prepare_script_upload(
-            script=script, update_re=update_re, run_in_background=run_in_background
+            script=script, update_lists=update_lists, update_re=update_re, run_in_background=run_in_background
         )
         self._clear_status_timestamp()
         return self.send_request(method="script_upload", params=request_params)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add support for the new `update_lists` parameter of `script_upload` API. See https://github.com/bluesky/bluesky-queueserver/pull/246 for more details.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Support for `update_lists` parameter of `script_upload` API.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit test were added.
