### PR TITLE
Support for 'lock', 'lock_info' and 'unlock' API

### DIFF
--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -561,6 +561,42 @@ class API_Async_Mixin(API_Base):
         self._clear_status_timestamp()
         return await self.send_request(method="re_halt")
 
+    async def lock(self, lock_key=None, *, environment=None, queue=None, note=None):
+        # Docstring is maintained separately
+        request_params = self._prepare_lock(environment=environment, queue=queue, lock_key=lock_key, note=note)
+        self._clear_status_timestamp()
+        return await self.send_request(method="lock", params=request_params)
+
+    async def lock_environment(self, lock_key=None, *, note=None):
+        # Docstring is maintained separately
+        return await self.lock(lock_key=lock_key, environment=True, note=note)
+
+    async def lock_queue(self, lock_key=None, *, note=None):
+        # Docstring is maintained separately
+        return await self.lock(lock_key=lock_key, queue=True, note=note)
+
+    async def lock_all(self, lock_key=None, *, note=None):
+        # Docstring is maintained separately
+        return await self.lock(lock_key=lock_key, environment=True, queue=True, note=note)
+
+    async def lock_info(self, lock_key=None, *, reload=False):
+        # Docstring is maintained separately
+        status = await self._status(reload=reload)
+        lock_info_uid = status["lock_info_uid"]
+        if (lock_info_uid != self._current_lock_info_uid) or (lock_key is not None):
+            request_params = self._prepare_lock_info(lock_key=lock_key)
+            response = await self.send_request(method="lock_info", params=request_params)
+            self._process_response_lock_info(response)
+        else:
+            response = self._generate_response_lock_info()
+        return response
+
+    async def unlock(self, lock_key=None):
+        # Docstring is maintained separately
+        request_params = self._prepare_unlock(lock_key=lock_key)
+        self._clear_status_timestamp()
+        return await self.send_request(method="unlock", params=request_params)
+
 
 API_Async_Mixin.status.__doc__ = _doc_api_status
 API_Async_Mixin.ping.__doc__ = _doc_api_ping

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -644,7 +644,7 @@ class API_Base:
         if not lock_key:
             raise RuntimeError("Failed to format the 'lock' request: Lock key is not set")
 
-        if not isinstance(note, (str, None)):
+        if not isinstance(note, (str, type(None))):
             raise ValueError(f"Parameter 'note' must be a string or None: note={note!r}")
         environment, queue = bool(environment), bool(queue)
 
@@ -671,13 +671,8 @@ class API_Base:
         return {"lock_key": lock_key}
 
     def _prepare_lock_info(self, *, lock_key):
-        # Lock key may be None. Use self.lock_key in this case.
+        # Lock key may be None.
         self._validate_lock_key(lock_key)
-        if not lock_key:
-            lock_key = self.lock_key
-        if not lock_key:
-            raise RuntimeError("Failed to format the 'lock_info' request: Lock key is not set")
-
         return {"lock_key": lock_key}
 
     def _process_response_lock_info(self, response):

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -558,6 +558,42 @@ class API_Threads_Mixin(API_Base):
         self._clear_status_timestamp()
         return self.send_request(method="re_halt")
 
+    def lock(self, lock_key=None, *, environment=None, queue=None, note=None):
+        # Docstring is maintained separately
+        request_params = self._prepare_lock(environment=environment, queue=queue, lock_key=lock_key, note=note)
+        self._clear_status_timestamp()
+        return self.send_request(method="lock", params=request_params)
+
+    def lock_environment(self, lock_key=None, *, note=None):
+        # Docstring is maintained separately
+        return self.lock(lock_key=lock_key, environment=True, note=note)
+
+    def lock_queue(self, lock_key=None, *, note=None):
+        # Docstring is maintained separately
+        return self.lock(lock_key=lock_key, queue=True, note=note)
+
+    def lock_all(self, lock_key=None, *, note=None):
+        # Docstring is maintained separately
+        return self.lock(lock_key=lock_key, environment=True, queue=True, note=note)
+
+    def lock_info(self, lock_key=None, *, reload=False):
+        # Docstring is maintained separately
+        status = self._status(reload=reload)
+        lock_info_uid = status["lock_info_uid"]
+        if lock_info_uid != self._current_lock_info_uid:
+            request_params = self._prepare_lock_info(lock_key=lock_key)
+            response = self.send_request(method="lock_info", params=request_params)
+            self._process_response_lock_info(response)
+        else:
+            response = self._generate_response_lock_info()
+        return response
+
+    def unlock(self, lock_key=None):
+        # Docstring is maintained separately
+        request_params = self._prepare_unlock(lock_key=lock_key)
+        self._clear_status_timestamp()
+        return self.send_request(method="unlock", params=request_params)
+
     # =======================================================================================
     #                            Console monitor
     # =======================================================================================

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -580,7 +580,8 @@ class API_Threads_Mixin(API_Base):
         # Docstring is maintained separately
         status = self._status(reload=reload)
         lock_info_uid = status["lock_info_uid"]
-        if lock_info_uid != self._current_lock_info_uid:
+        # If lock key is specified, then always send the request
+        if (lock_info_uid != self._current_lock_info_uid) or (lock_key is not None):
             request_params = self._prepare_lock_info(lock_key=lock_key)
             response = self.send_request(method="lock_info", params=request_params)
             self._process_response_lock_info(response)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added support for `lock`, `lock_info` and `unlock` API (see https://github.com/bluesky/bluesky-queueserver/pull/248).
The new API introduced in this PR:

- `REManagerAPI.lock()`
- `REManagerAPI.lock_environment()`
- `REManagerAPI.lock_queue()`
- `REManagerAPI.lock_any()`
- `REManagerAPI.lock_info()`
- `REManagerAPI.unlock()`

Additional methods and properties (no communication with the server):

- `REManagerAPI.default_lock_key_path` (read-write property)
- `REManagerAPI.get_default_lock_key()`
- `REManagerAPI.set_default_lock_key()`
- `REManagerAPI.lock_key` (read-write property)
- `REManagerAPI.enable_locked_api` (read-write property)

The work on the API is not finished. The current implementation is sufficient to add the API support to HTTP Server, which is required to complete work on the API in this project.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Support for `lock`, `lock_info` and `unlock` API of RE Manager. New methods for REManagerAPI: `lock()`, `lock_environment()`, `lock_queue()`, `lock_all()`, `lock_info()`, `unlock()`. Additional methods and properties: `default_lock_key_path`, `get_default_lock_key()`, `set_default_lock_key()`, `lock_key`, `enable_locked_api`.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests are implemented.
