### PR TITLE
Complete implementation on API for locking/unlocking RE Manager

### DIFF
--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -300,49 +300,71 @@ class API_Async_Mixin(API_Base):
     # =====================================================================================
     #                 API for monitoring and control of Queue
 
-    async def item_add(self, item, *, pos=None, before_uid=None, after_uid=None, user=None, user_group=None):
+    async def item_add(
+        self, item, *, pos=None, before_uid=None, after_uid=None, user=None, user_group=None, lock_key=None
+    ):
         # Docstring is maintained separately
         request_params = self._prepare_item_add(
-            item=item, pos=pos, before_uid=before_uid, after_uid=after_uid, user=user, user_group=user_group
+            item=item,
+            pos=pos,
+            before_uid=before_uid,
+            after_uid=after_uid,
+            user=user,
+            user_group=user_group,
+            lock_key=lock_key,
         )
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_add", params=request_params)
 
     async def item_add_batch(
-        self, items, *, pos=None, before_uid=None, after_uid=None, user=None, user_group=None
+        self, items, *, pos=None, before_uid=None, after_uid=None, user=None, user_group=None, lock_key=None
     ):
         # Docstring is maintained separately
         request_params = self._prepare_item_add_batch(
-            items=items, pos=pos, before_uid=before_uid, after_uid=after_uid, user=user, user_group=user_group
+            items=items,
+            pos=pos,
+            before_uid=before_uid,
+            after_uid=after_uid,
+            user=user,
+            user_group=user_group,
+            lock_key=lock_key,
         )
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_add_batch", params=request_params)
 
-    async def item_update(self, item, *, replace=None, user=None, user_group=None):
+    async def item_update(self, item, *, replace=None, user=None, user_group=None, lock_key=None):
         # Docstring is maintained separately
-        request_params = self._prepare_item_update(item=item, replace=replace, user=user, user_group=user_group)
+        request_params = self._prepare_item_update(
+            item=item, replace=replace, user=user, user_group=user_group, lock_key=lock_key
+        )
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_update", params=request_params)
 
-    async def item_remove(self, *, pos=None, uid=None):
-        request_params = self._prepare_item_get_remove(pos=pos, uid=uid)
+    async def item_remove(self, *, pos=None, uid=None, lock_key=None):
+        request_params = self._prepare_item_remove(pos=pos, uid=uid, lock_key=lock_key)
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_remove", params=request_params)
 
-    async def item_remove_batch(self, *, uids, ignore_missing=None):
-        request_params = self._prepare_item_remove_batch(uids=uids, ignore_missing=ignore_missing)
+    async def item_remove_batch(self, *, uids, ignore_missing=None, lock_key=None):
+        request_params = self._prepare_item_remove_batch(
+            uids=uids, ignore_missing=ignore_missing, lock_key=lock_key
+        )
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_remove_batch", params=request_params)
 
-    async def item_move(self, *, pos=None, uid=None, pos_dest=None, before_uid=None, after_uid=None):
+    async def item_move(
+        self, *, pos=None, uid=None, pos_dest=None, before_uid=None, after_uid=None, lock_key=None
+    ):
         # Docstring is maintained separately
         request_params = self._prepare_item_move(
-            pos=pos, uid=uid, pos_dest=pos_dest, before_uid=before_uid, after_uid=after_uid
+            pos=pos, uid=uid, pos_dest=pos_dest, before_uid=before_uid, after_uid=after_uid, lock_key=lock_key
         )
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_move", params=request_params)
 
-    async def item_move_batch(self, *, uids=None, pos_dest=None, before_uid=None, after_uid=None, reorder=None):
+    async def item_move_batch(
+        self, *, uids=None, pos_dest=None, before_uid=None, after_uid=None, reorder=None, lock_key=None
+    ):
         # Docstring is maintained separately
         request_params = self._prepare_item_move_batch(
             uids=uids,
@@ -350,12 +372,13 @@ class API_Async_Mixin(API_Base):
             before_uid=before_uid,
             after_uid=after_uid,
             reorder=reorder,
+            lock_key=lock_key,
         )
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_move_batch", params=request_params)
 
     async def item_get(self, *, pos=None, uid=None):
-        request_params = self._prepare_item_get_remove(pos=pos, uid=uid)
+        request_params = self._prepare_item_get(pos=pos, uid=uid)
         return await self.send_request(method="queue_item_get", params=request_params)
 
     async def item_execute(self, item, *, user=None, user_group=None):
@@ -420,10 +443,11 @@ class API_Async_Mixin(API_Base):
             response = self._generate_response_history_get()
         return response
 
-    async def history_clear(self):
+    async def history_clear(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return await self.send_request(method="history_clear")
+        request_params = self._prepare_history_clear(lock_key=lock_key)
+        return await self.send_request(method="history_clear", params=request_params)
 
     async def plans_allowed(self, *, reload=False, user_group=None):
         # Docstring is maintained separately
@@ -477,10 +501,12 @@ class API_Async_Mixin(API_Base):
             response = self._generate_response_devices_existing()
         return response
 
-    async def permissions_reload(self, *, restore_plans_devices=None, restore_permissions=None):
+    async def permissions_reload(self, *, restore_plans_devices=None, restore_permissions=None, lock_key=None):
         # Docstring is maintained separately
         request_params = self._prepare_permissions_reload(
-            restore_plans_devices=restore_plans_devices, restore_permissions=restore_permissions
+            restore_plans_devices=restore_plans_devices,
+            restore_permissions=restore_permissions,
+            lock_key=lock_key,
         )
         self._clear_status_timestamp()
         return await self.send_request(method="permissions_reload", params=request_params)
@@ -489,9 +515,11 @@ class API_Async_Mixin(API_Base):
         # Docstring is maintained separately
         return await self.send_request(method="permissions_get")
 
-    async def permissions_set(self, user_group_permissions):
+    async def permissions_set(self, user_group_permissions, *, lock_key=None):
         # Docstring is maintained separately
-        request_params = self._prepare_permissions_set(user_group_permissions=user_group_permissions)
+        request_params = self._prepare_permissions_set(
+            user_group_permissions=user_group_permissions, lock_key=lock_key
+        )
         self._clear_status_timestamp()
         return await self.send_request(method="permissions_set", params=request_params)
 

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -561,23 +561,25 @@ class API_Async_Mixin(API_Base):
         self._clear_status_timestamp()
         return await self.send_request(method="re_halt")
 
-    async def lock(self, lock_key=None, *, environment=None, queue=None, note=None):
+    async def lock(self, lock_key=None, *, environment=None, queue=None, note=None, user=None):
         # Docstring is maintained separately
-        request_params = self._prepare_lock(environment=environment, queue=queue, lock_key=lock_key, note=note)
+        request_params = self._prepare_lock(
+            environment=environment, queue=queue, lock_key=lock_key, note=note, user=user
+        )
         self._clear_status_timestamp()
         return await self.send_request(method="lock", params=request_params)
 
-    async def lock_environment(self, lock_key=None, *, note=None):
+    async def lock_environment(self, lock_key=None, *, note=None, user=None):
         # Docstring is maintained separately
-        return await self.lock(lock_key=lock_key, environment=True, note=note)
+        return await self.lock(lock_key=lock_key, environment=True, note=note, user=user)
 
-    async def lock_queue(self, lock_key=None, *, note=None):
+    async def lock_queue(self, lock_key=None, *, note=None, user=None):
         # Docstring is maintained separately
-        return await self.lock(lock_key=lock_key, queue=True, note=note)
+        return await self.lock(lock_key=lock_key, queue=True, note=note, user=user)
 
-    async def lock_all(self, lock_key=None, *, note=None):
+    async def lock_all(self, lock_key=None, *, note=None, user=None):
         # Docstring is maintained separately
-        return await self.lock(lock_key=lock_key, environment=True, queue=True, note=note)
+        return await self.lock(lock_key=lock_key, environment=True, queue=True, note=note, user=user)
 
     async def lock_info(self, lock_key=None, *, reload=False):
         # Docstring is maintained separately

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -47,6 +47,12 @@ from .api_docstrings import (
     _doc_api_re_stop,
     _doc_api_re_abort,
     _doc_api_re_halt,
+    _doc_api_lock,
+    _doc_api_lock_environment,
+    _doc_api_lock_queue,
+    _doc_api_lock_all,
+    _doc_api_lock_info,
+    _doc_api_unlock,
 )
 
 
@@ -693,3 +699,9 @@ API_Async_Mixin.re_resume.__doc__ = _doc_api_re_resume
 API_Async_Mixin.re_stop.__doc__ = _doc_api_re_stop
 API_Async_Mixin.re_abort.__doc__ = _doc_api_re_abort
 API_Async_Mixin.re_halt.__doc__ = _doc_api_re_halt
+API_Async_Mixin.lock.__doc__ = _doc_api_lock
+API_Async_Mixin.lock_environment.__doc__ = _doc_api_lock_environment
+API_Async_Mixin.lock_queue.__doc__ = _doc_api_lock_queue
+API_Async_Mixin.lock_all.__doc__ = _doc_api_lock_all
+API_Async_Mixin.lock_info.__doc__ = _doc_api_lock_info
+API_Async_Mixin.unlock.__doc__ = _doc_api_unlock

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -423,7 +423,7 @@ class API_Async_Mixin(API_Base):
         request_params = self._prepare_environment_control(lock_key=lock_key)
         return await self.send_request(method="queue_stop_cancel", params=request_params)
 
-    async def queue_clear(self, *, lock_key):
+    async def queue_clear(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
         request_params = self._prepare_queue_clear(lock_key=lock_key)

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -381,39 +381,53 @@ class API_Async_Mixin(API_Base):
         request_params = self._prepare_item_get(pos=pos, uid=uid)
         return await self.send_request(method="queue_item_get", params=request_params)
 
-    async def item_execute(self, item, *, user=None, user_group=None):
+    async def item_execute(self, item, *, user=None, user_group=None, lock_key=None):
         # Docstring is maintained separately
-        request_params = self._prepare_item_execute(item=item, user=user, user_group=user_group)
+        request_params = self._prepare_item_execute(item=item, user=user, user_group=user_group, lock_key=lock_key)
         self._clear_status_timestamp()
         return await self.send_request(method="queue_item_execute", params=request_params)
 
-    async def environment_open(self):
+    async def environment_open(self, *, lock_key=None):
+        # Docstring is maintained separately
         self._clear_status_timestamp()
-        return await self.send_request(method="environment_open")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return await self.send_request(method="environment_open", params=request_params)
 
-    async def environment_close(self):
+    async def environment_close(self, *, lock_key=None):
+        # Docstring is maintained separately
         self._clear_status_timestamp()
-        return await self.send_request(method="environment_close")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return await self.send_request(method="environment_close", params=request_params)
 
-    async def environment_destroy(self):
+    async def environment_destroy(self, *, lock_key=None):
+        # Docstring is maintained separately
         self._clear_status_timestamp()
-        return await self.send_request(method="environment_destroy")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return await self.send_request(method="environment_destroy", params=request_params)
 
-    async def queue_start(self):
+    async def queue_start(self, *, lock_key=None):
+        # Docstring is maintained separately
         self._clear_status_timestamp()
-        return await self.send_request(method="queue_start")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return await self.send_request(method="queue_start", params=request_params)
 
-    async def queue_stop(self):
+    async def queue_stop(self, *, lock_key=None):
+        # Docstring is maintained separately
         self._clear_status_timestamp()
-        return await self.send_request(method="queue_stop")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return await self.send_request(method="queue_stop", params=request_params)
 
-    async def queue_stop_cancel(self):
+    async def queue_stop_cancel(self, *, lock_key=None):
+        # Docstring is maintained separately
         self._clear_status_timestamp()
-        return await self.send_request(method="queue_stop_cancel")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return await self.send_request(method="queue_stop_cancel", params=request_params)
 
-    async def queue_clear(self):
+    async def queue_clear(self, *, lock_key):
+        # Docstring is maintained separately
         self._clear_status_timestamp()
-        return await self.send_request(method="queue_clear")
+        request_params = self._prepare_queue_clear(lock_key=lock_key)
+        return await self.send_request(method="queue_clear", params=request_params)
 
     async def queue_mode_set(self, **kwargs):
         # Docstring is maintained separately
@@ -523,18 +537,24 @@ class API_Async_Mixin(API_Base):
         self._clear_status_timestamp()
         return await self.send_request(method="permissions_set", params=request_params)
 
-    async def script_upload(self, script, *, update_lists=None, update_re=None, run_in_background=None):
+    async def script_upload(
+        self, script, *, update_lists=None, update_re=None, run_in_background=None, lock_key=None
+    ):
         # Docstring is maintained separately
         request_params = self._prepare_script_upload(
-            script=script, update_lists=update_lists, update_re=update_re, run_in_background=run_in_background
+            script=script,
+            update_lists=update_lists,
+            update_re=update_re,
+            run_in_background=run_in_background,
+            lock_key=lock_key,
         )
         self._clear_status_timestamp()
         return await self.send_request(method="script_upload", params=request_params)
 
-    async def function_execute(self, item, *, run_in_background=None, user=None, user_group=None):
+    async def function_execute(self, item, *, run_in_background=None, user=None, user_group=None, lock_key=None):
         # Docstring is maintained separately
         request_params = self._prepare_function_execute(
-            item=item, run_in_background=run_in_background, user=user, user_group=user_group
+            item=item, run_in_background=run_in_background, user=user, user_group=user_group, lock_key=lock_key
         )
         self._clear_status_timestamp()
         return await self.send_request(method="function_execute", params=request_params)
@@ -563,31 +583,35 @@ class API_Async_Mixin(API_Base):
             response = self._generate_response_re_runs(option=option)
         return response
 
-    async def re_pause(self, option=None):
+    async def re_pause(self, option=None, *, lock_key=None):
         # Docstring is maintained separately
-        request_params = self._prepare_re_pause(option=option)
+        request_params = self._prepare_re_pause(option=option, lock_key=lock_key)
         self._clear_status_timestamp()
         return await self.send_request(method="re_pause", params=request_params)
 
-    async def re_resume(self):
+    async def re_resume(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return await self.send_request(method="re_resume")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return await self.send_request(method="re_resume", params=request_params)
 
-    async def re_stop(self):
+    async def re_stop(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return await self.send_request(method="re_stop")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return await self.send_request(method="re_stop", params=request_params)
 
-    async def re_abort(self):
+    async def re_abort(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return await self.send_request(method="re_abort")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return await self.send_request(method="re_abort", params=request_params)
 
-    async def re_halt(self):
+    async def re_halt(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return await self.send_request(method="re_halt")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return await self.send_request(method="re_halt", params=request_params)
 
     async def lock(self, lock_key=None, *, environment=None, queue=None, note=None, user=None):
         # Docstring is maintained separately

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -275,7 +275,7 @@ class API_Base:
         If ``lock_key`` is None, then try to use the 'current' lock key.
         If the passed and 'current' lock key is None, then do not add the key.
         """
-        self.validate_lock_key(lock_key)
+        self._validate_lock_key(lock_key)
         if not lock_key and self._enable_locked_api:
             lock_key = self._lock_key
         if lock_key:

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -392,7 +392,7 @@ class API_Base:
         self._add_lock_key(request_params, lock_key)
         return request_params
 
-    def _prepare_item_execute(self, *, item, user, user_group):
+    def _prepare_item_execute(self, *, item, user, user_group, lock_key):
         """
         Prepare parameters for ``item_execute`` operation.
         """
@@ -403,6 +403,7 @@ class API_Base:
 
         request_params = {"item": item}
         self._request_params_add_user_info(request_params, user=user, user_group=user_group)
+        self._add_lock_key(request_params, lock_key)
         return request_params
 
     def _prepare_history_clear(self, *, lock_key):
@@ -596,7 +597,15 @@ class API_Base:
         self._add_lock_key(request_params, lock_key)
         return request_params
 
-    def _prepare_script_upload(self, *, script, update_lists, update_re, run_in_background):
+    def _prepare_environment_control(self, *, lock_key):
+        """
+        Prepare parameters for generic API for environment control which accepts only 'lock_key'``
+        """
+        request_params = {}
+        self._add_lock_key(request_params, lock_key)
+        return request_params
+
+    def _prepare_script_upload(self, *, script, update_lists, update_re, run_in_background, lock_key):
         """
         Prepare parameters for ``script_upload``
         """
@@ -604,9 +613,10 @@ class API_Base:
         self._add_request_param(request_params, "update_lists", update_lists)
         self._add_request_param(request_params, "update_re", update_re)
         self._add_request_param(request_params, "run_in_background", run_in_background)
+        self._add_lock_key(request_params, lock_key)
         return request_params
 
-    def _prepare_function_execute(self, *, item, run_in_background, user, user_group):
+    def _prepare_function_execute(self, *, item, run_in_background, user, user_group, lock_key):
         """
         Prepare parameters for ``script_upload``
         """
@@ -618,6 +628,7 @@ class API_Base:
         request_params = {"item": item}
         self._add_request_param(request_params, "run_in_background", run_in_background)
         self._request_params_add_user_info(request_params, user=user, user_group=user_group)
+        self._add_lock_key(request_params, lock_key)
         return request_params
 
     def _prepare_task_result(self, *, task_uid):
@@ -670,12 +681,13 @@ class API_Base:
         }
         return response
 
-    def _prepare_re_pause(self, *, option):
+    def _prepare_re_pause(self, *, option, lock_key):
         """
         Prepare parameters for ``re_pause`` operation
         """
         request_params = {}
         self._add_request_param(request_params, "option", option)
+        self._add_lock_key(request_params, lock_key)
         return request_params
 
     def _validate_lock_key(self, lock_key):

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -761,15 +761,15 @@ class API_Base:
 
     @property
     def default_lock_key_path(self):
-        return self._default_lock_key_path
-
-    @default_lock_key_path.setter
-    def default_lock_key_path(self, lock_key_path):
         """
         Get/set path of the file with the default lock key. The default path is
         ``<user-home-dir>.config/qserver/default_lock_key.txt``. In some workflows
         it may be useful to set a different path.
         """
+        return self._default_lock_key_path
+
+    @default_lock_key_path.setter
+    def default_lock_key_path(self, lock_key_path):
         self._default_lock_key_path = lock_key_path
 
     def get_default_lock_key(self, new_key=False):

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -636,7 +636,7 @@ class API_Base:
             if not isinstance(lock_key, str) or not lock_key:
                 raise ValueError(f"Parameter 'lock_key' must be non-empty string or None: lock_key={lock_key!r}")
 
-    def _prepare_lock(self, *, environment, queue, lock_key, note):
+    def _prepare_lock(self, *, environment, queue, lock_key, note, user):
         # Lock key may be None. Use self.lock_key in this case.
         self._validate_lock_key(lock_key)
         if not lock_key:
@@ -654,7 +654,11 @@ class API_Base:
         if queue:
             request_params["queue"] = queue
         request_params["lock_key"] = lock_key
-        request_params["user"] = self._user
+
+        self._request_params_add_user_info(request_params, user=user, user_group=None)
+        if "user_group" in request_params:
+            del request_params["user_group"]
+
         if note:
             request_params["note"] = note
 

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -2170,3 +2170,338 @@ _doc_api_re_halt = """
     Request Run Engine to halt paused plan. See documentation for ``re_pause`` API
     for more detailed information.
 """
+
+_doc_api_lock = """
+    Lock RE Manager with a lock key. The lock may prevent other users (or clients) from modifying
+    the environment, starting plans or tasks or editing the queue. The API is intented to
+    supports the scenarios when a beamline scientist needs to lock RE Manager with
+    a unique code before entering the hutch to change samples or make adjustments and then
+    safely run a series of calibration or testing plans without interference from automated
+    agents or remote users. A remote operators may still control locked RE Manager if
+    the beamline scientist provides them with the lock key.
+
+    The lock is not intended for access control. The read-only API are not affected by the lock,
+    therefore all monitoring client applications are expected to remain functional after
+    the lock is applied. The lock  does not influence internal operation of the manager,
+    e.g. the running queue will continue running and has to be explicitly stopped if needed.
+    Restarting RE Manager does not remove the lock. The locked manager must be unlocked
+    with ``REManagerAPI.unlock()`` API using the valid lock key (normal operation), an optional
+    emergency lock key (in case the lock key is lost) or ``qserver-clear-lock`` CLI tool (last
+    resort, requires restarting RE Manager).
+
+    The lock can be set using current lock key (set using ``REManagerAPI.lock_key`` property)
+    or passed to the API directly using the ``lock_key`` parameter. The key passed as a parameter
+    always overrides the current lock key. The operator may still execute locked API using a valid
+    lock key. If access to locked API is enabled (``REManagerAPI.enable_locked_api`` is ``True``),
+    then the current lock key is automatically passed with each lockable API. The key passed
+    with ``lock_api`` parameter overrides the current key and is always passed with the API
+    call. This mechanism allows to set the key only once (``RM.lock_key="some-lock-key"``)
+    and use it to lock and unlock the manager and access the locked API if needed.
+    The ``lock_key`` API parameter is used in applications where setting a global lock key
+    is not desirable (e.g. in the implementation of multi-user HTTP Server).
+
+    The API parameters allow to choose between locking the **environment**, the **queue** or both.
+    The **environment** is locked by setting ``environment=True`` or calling ``REManagerAPI.lock_environment()``
+    and affects the following API:
+
+    - REManagerAPI.environment_open()
+    - REManagerAPI.environment_close()
+    - REManagerAPI.environment_destroy()
+    - REManagerAPI.queue_start()
+    - REManagerAPI.queue_stop()
+    - REManagerAPI.queue_stop_cancel()
+    - REManagerAPI.item_execute()
+    - REManagerAPI.re_pause()
+    - REManagerAPI.re_resume()
+    - REManagerAPI.re_stop()
+    - REManagerAPI.re_abort()
+    - REManagerAPI.re_halt()
+    - REManagerAPI.script_upload()
+    - REManagerAPI.function_execute()
+
+    The **queue** is locked by setting ``queue=True`` or calling ``REManagerAPI.lock_queue()`` and
+    affects the following API:
+
+    - REManagerAPI.queue_mode_set()
+    - REManagerAPI.item_add()
+    - REManagerAPI.item_add_batch()
+    - REManagerAPI.item_update()
+    - REManagerAPI.item_remove()
+    - REManagerAPI.item_remove_batch()
+    - REManagerAPI.item_move()
+    - REManagerAPI.item_move_batch()
+    - REManagerAPI.queue_clear()
+    - REManagerAPI.history_clear()
+    - REManagerAPI.permissions_reload()
+    - REManagerAPI.permissions_set()
+
+    The **environment** and the **queue** may be locked by setting ``environment=True``, ``queue=True``
+    or calling ``REManagerAPI.lock_all()`` and affects the API from both groups.
+
+    The additional parameters include the name of the user (``user``) who is locking
+    RE Manager and an optional note (message) passed to other users (``note``), which explains
+    the reason why the manager is locked. The user name and the note is returned by
+    ``lock_info`` API and included in the *'Invalid lock key'* error messages.
+
+    The API may be called if RE Manager is already locked to change the lock options or the note.
+    In this case, the lock key passed with the request must match the key used to lock the manager.
+    There is no API that allows to change the lock without unlocking the manager.
+
+    Examples
+    --------
+
+    Setting and using current lock key (sync and async API).
+
+    .. code-block:: python
+
+        # Set current lock key. The key may be any string.
+        #   The default lock key persists between sessions.
+        RM.lock_key = RM.get_default_lock_key()
+
+        RM.lock(environment=True, note="Some informative message ...")
+        # await RM.lock(environment=True, note="Some informative message ...")
+
+        response = RM.lock_info()
+        # response = await RM.lock_info()
+        print(response["lock_info"])
+
+        RM.lock_queue(note="Another message ...")
+        # await RM.lock_queue(note="Another message ...")
+
+        RM.lock_environment(note="Different message ...")
+        # await RM.lock_environment(note="Different message ...")
+
+        RM.lock_all(note="Any useful message ...")
+        # await RM.lock_environment(note="Any useful message ...")
+
+        try:
+            RM.environment_open()  # API call fails because the environment is locked.
+            # await RM.environment_open()
+        except Exception as ex:
+            print(f"API call failed: {ex}")
+
+        # If locked API are enabled, then the current lock key is sent with each API request.
+        RM.enable_locked_api()
+
+        RM.environment_open()  # API call is expected to succeed.
+        # await RM.environment_open()
+
+        RM.unlock()
+        # await RM.unlock()
+
+    Explicitly passing the lock key as a parameter (sync and async API).
+
+    .. code-block:: python
+
+        # Select the lock key. The key may be any string.
+        #   The default lock key persists between sessions.
+        lock_key = "some-arbitrary-string-key"
+        # lock_key = RM.get_default_lock_key()
+
+        RM.lock(lock_key=lock_key, environment=True, note="Some informative message ...")
+        # await RM.lock(lock_key=lock_key, environment=True, note="Some informative message ...")
+
+        response = RM.lock_info()
+        # response = await RM.lock_info()
+        print(response["lock_info"])
+
+        RM.lock_queue(lock_key=lock_key, note="Another message ...")
+        # await RM.lock_queue(lock_key=lock_key, note="Another message ...")
+
+        RM.lock_environment(lock_key=lock_key, note="Different message ...")
+        # await RM.lock_environment(lock_key=lock_key, note="Different message ...")
+
+        RM.lock_all(lock_key=lock_key, note="Any useful message ...")
+        # await RM.lock_environment(lock_key=lock_key, note="Any useful message ...")
+
+        try:
+            RM.environment_open()  # API call fails because the environment is locked.
+            # await RM.environment_open()
+        except Exception as ex:
+            print(f"API call failed: {ex}")
+
+
+        RM.environment_open(lock_key=lock_key)  # API call is expected to succeed.
+        # await RM.environment_open(lock_key=lock_key)
+
+        RM.unlock(lock_key=lock_key)
+        # await RM.unlock(lock_key=lock_key)
+
+
+
+    Parameters
+    ----------
+    lock_key: str (optional)
+        The lock key is an arbitrary non-empty string. Users/clients are expected to keep
+        the key used to lock RE Manager and use it to unlock the manager or make API requests.
+        If the lock key is lost by accident, then RE Manager may be unlocked using the
+        emergency lock key. If ``lock_key`` is not set, then the current key
+        (``REManagerAPI.lock_key`` property) is used. If neither keys are set, then
+        ``RuntimeError`` (*lock key is not set*) is raised.
+    environment: boolean (optional)
+        Enable lock for the API that control RE Worker environment. The request fails
+        if both **environment** and **queue** are missing or *False*. Default: ``False``.
+    queue: boolean (optinal)
+        Enable lock for the API that control the queue. The request fails
+        if both **environment** and **queue** are missing or *False*. Default: ``False``.
+    user: str (optional)
+        Name of the user who submits the request. The user name is returned as part of
+        *lock_info* and included in error messages. If the parameter is missing or ``None``,
+        then ``REManagerAPI.user`` is passed with the API call. Default: ``None``.
+    note: str or None (optional)
+        A text message to other users that explains the reason why RE Manager is locked.
+        The note is returned as part of *lock_info* and included in error messages.
+        If the value is ``None``, then no message submitted. Default: ``None``.
+
+    Returns
+    -------
+    response: dict
+
+        Dictionary keys:
+
+        - ``success``: *boolean* - success of the request.
+
+        - ``msg``: *str* - error message in case the request is rejected by RE Manager
+          or operation failed.
+
+
+        - ``lock_info``: *dict* - dictionary containing the information on the status of the lock.
+          The dictionary is also returned by ``REManagerAPI.lock_info()`` and includes
+          the following fields:
+
+          - ``environment``: *boolean* - indicates if the RE Worker environment is locked.
+
+          - ``queue``: *boolean* - indicates if the queue is locked.
+
+          - ``user``: *str* or *None* - the name of the user who locked RE Manager,
+            ``None`` if the lock is not set.
+
+          - ``note``: *str* or *None* - the text note left by the user who locked RE Manager,
+            ``None`` if the lock is not set.
+
+          - ``time``: *float* or *None* - timestamp (time when RE Manager was locked),
+            ``None`` if the lock is not set.
+
+          - ``time_str``: *str* - human-readable representation of the timestamp,
+            empty string if the lock is not set.
+
+          - ``emergency_lock_key_is_set``: *boolean* - indicates if the optional emergency
+            lock key is set.
+
+        - ``lock_info_uid``: *str*
+          UID of *lock_info*. The UID is also returned in RE Manager status and could be
+          monitored to detect updates of *lock_info*.
+
+    Raises
+    ------
+    RequestTimeoutError, RequestFailedError, RequestError, ClientError
+        All exceptions raised by ``send_request`` API.
+    RuntimeError
+        The lock key (``lock_key`` parameter) is not passed and the current lock key
+        (``REManagerAPI.lock_key``) is not set.
+"""
+
+_doc_api_lock_environment = """
+    Locks the environment in RE Manager. The API is identical to ``REManagerAPI.lock()``
+    called with ``environment=True`` and ``queue=False``. See the docstring for
+    ``REManagerAPI.lock()`` for more details.
+"""
+
+_doc_api_lock_queue = """
+    Locks the queue in RE Manager. The API is identical to ``REManagerAPI.lock()``
+    called with ``environment=False`` and ``queue=True``. See the docstring for
+    ``REManagerAPI.lock()`` for more details.
+"""
+
+_doc_api_lock_all = """
+    Locks the environment and the queue in RE Manager. The API is identical
+    to ``REManagerAPI.lock()`` called with ``environment=True`` and ``queue=True``.
+    See the docstring for ``REManagerAPI.lock()`` for more details.
+"""
+
+_doc_api_lock_info = """
+    Returns status information of the current lock. Optionally validates
+    the lock key if it is passed with API request.
+
+    If the ``lock_key`` parameter is not ``None``, then the request is always forwarded
+    to the RE Manager. Do not pass the lock key unless validation to avoid unnecessary
+    overhead.
+
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        A lock key to validate. The API call fails if the lock key is invalid.
+        Default: None.
+    reload: boolean (optional)
+        Set the parameter ``True`` to force reloading the status from the server before
+        ``lock_info_uid`` is checked. Otherwise cached status is used. Default: False.
+
+    Returns
+    -------
+    response: dict
+
+        Dictionary keys:
+
+        - ``success``: *boolean* - success of the request. The request always succeeds if
+          ``lock_key`` is missing or ``None``. If the key is passed, then the request succeeds
+          if the key is valid and fails otherwise.
+
+        - ``msg``: *str* - error message in case the request is rejected by RE Manager
+          or operation failed.
+
+        - ``lock_info``: *dict* - dictionary containing the information on the status of the lock.
+          See the docstring for ``REManagerAPI.lock()`` for detailed description.
+
+        - ``lock_info_uid``: *str*
+          UID of *lock_info*. The UID is also returned in RE Manager status and could be
+          monitored to detect updates of *lock_info*.
+
+    Raises
+    ------
+    RequestTimeoutError, RequestFailedError, RequestError, ClientError
+        All exceptions raised by ``send_request`` API.
+    ValueError
+        The lock key is not a non-empty string.
+"""
+
+_doc_api_unlock = """
+    Unlock RE Manager. The manager may be unlocked using a valid lock key (used to lock the manager)
+    or an emergency lock key (if set). The lock key using ``REManagerAPI.lock_key`` (current lock key)
+    or passed as a parameter (overrides the current lock key). ``RuntimeError`` is raised if
+    the key is not set.
+
+    Parameters
+    ----------
+    lock_key: str (optional)
+        Valid lock key or emergency lock key (if set). If ``lock_key`` is missing or ``None``,
+        then the current key (``REManagerAPI.lock_key`` property) is used. If neither keys are set,
+        then ``RuntimeError`` (*lock key is not set*) is raised.
+
+    Returns
+    -------
+    response: dict
+
+        Dictionary keys:
+
+        - ``success``: *boolean* - success of the request.
+
+        - ``msg``: *str* - error message in case the request is rejected by RE Manager
+          or operation failed.
+
+        - ``lock_info``: *dict* - dictionary containing the information on the status of the lock.
+          See the docstring for ``REManagerAPI.lock()`` for detailed description.
+
+        - ``lock_info_uid``: *str*
+          UID of *lock_info*. The UID is also returned in RE Manager status and could be
+          monitored to detect updates of *lock_info*.
+
+    Raises
+    ------
+    RequestTimeoutError, RequestFailedError, RequestError, ClientError
+        All exceptions raised by ``send_request`` API.
+    ValueError
+        The lock key is not a non-empty string.
+    RuntimeError
+        The lock key (``lock_key`` parameter) is not passed and the current lock key
+        (``REManagerAPI.lock_key``) is not set.
+"""

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -462,6 +462,11 @@ _doc_api_item_add = """
         ``user_group`` properties). The default user or user group name is used
         if the respective parameter is not specified or ``None``. The parameters are
         ignored by the HTTP version of the API.
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -558,6 +563,11 @@ _doc_api_item_add_batch = """
         ``user_group`` properties). The default user or user group name is used
         if the respective parameter is not specified or ``None``. The parameters are
         ignored by the HTTP version of the API.
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -625,6 +635,11 @@ _doc_api_item_update = """
         ``user_group`` properties). The default user or user group name is used
         if the respective parameter is not specified or ``None``. The parameters are
         ignored by the HTTP version of the API.
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -733,6 +748,11 @@ _doc_api_item_remove = """
         is not specified.
     uid: str or None
         UID of the item. If ``None`` (default), then the parameter are not specified.
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -787,6 +807,11 @@ _doc_api_item_remove_batch = """
         items or some of the batch items are not found in the queue. If ``True`` (default),
         then the method attempts to remove all items in the batch and ignores missing
         items. The method returns the list of items that were removed from the queue.
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -842,6 +867,11 @@ _doc_api_item_move = """
     before_uid, after_uid: str or None
         UID of an existing item in the queue. The selected item is moved before
         or after this item. If ``None`` (default), then the parameter are not specified.
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -906,6 +936,11 @@ _doc_api_item_move_batch = """
     reorder: boolean
         Arrange moved items in the order of UIDs in the ``uids`` list (False, default) or
         according to the original item positions in the queue (True).
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -964,6 +999,11 @@ _doc_api_item_execute = """
         ``user_group`` properties). The default user or user group name is used
         if the respective parameter is not specified or ``None``. The parameters are
         ignored by the HTTP version of the API.
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -1005,6 +1045,14 @@ _doc_api_queue_start = """
     then ``"executing_queue"``. Once queue execution is completed or stopped,
     the manager state returns to ``"idle"``.
 
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
+
     Returns
     -------
     response: dict
@@ -1038,6 +1086,14 @@ _doc_api_queue_stop = """
     running plan. The request succeeds only if the queue is currently running (``manager_state``
     status field has value ``executing_queue``). Use the status field ``queue_stop_pending``
     to verify if the request is pending.
+
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -1073,6 +1129,14 @@ _doc_api_queue_stop_cancel = """
     Cancel the pending request to stop execution of the queue after the currently running plan.
     Use the status field ``queue_stop_pending``  to check if the request is pending.
 
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
+
     Returns
     -------
     response: dict
@@ -1106,6 +1170,14 @@ _doc_api_queue_clear = """
     Remove all items from the plan queue. The currently running plan does not belong
     to the queue and is not affected by this operation. Failed or stopped plans are
     pushed to the front of the queue.
+
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -1152,6 +1224,11 @@ _doc_api_queue_mode_set = """
         ignored if ``mode`` kwarg is passed.
     loop: boolean
         Turns LOOP mode ON and OFF
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -1289,6 +1366,14 @@ _doc_api_history_get = """
 
 _doc_api_history_clear = """
     Remove all items from the history.
+
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -1523,10 +1608,15 @@ _doc_api_permissions_reload = """
     ----------
     restore_plans_devices: boolean (optional)
         Reload the lists of existing plans and devices from disk if True, otherwise
-        use current lists stored in memory. Default: False.
+        use current lists stored in memory. Default: ``False``.
     restore_permissions: boolean (optional)
         Reload user group permissions from disk if True, otherwise use current
-        permissions. Default: True.
+        permissions. Default: ``True``.
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -1605,6 +1695,11 @@ _doc_api_permissions_set = """
     ----------
     user_group_permissions: dict
         Dictionary, which contains user group permissions.
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -1648,6 +1743,14 @@ _doc_api_environment_open = """
     changed back to ``idle`` when the operation is complete. Check
     ``worker_environment_exists`` to see if the environment was opened successfully.
 
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
+
     Returns
     -------
     response: dict
@@ -1683,6 +1786,14 @@ _doc_api_environment_close = """
     to change to ``closing_environment`` and then back to ``idle`` when the operation
     is completed. Check ``worker_environment_exists`` status flag to see if
     the environment was closed.
+
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -1722,6 +1833,14 @@ _doc_api_environment_destroy = """
     to change to ``destroying_environment`` and then to ``idle`` when the operation
     is completed. Check ``worker_environment_exists`` status flag to see if
     the environment was destroyed.
+
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -1787,6 +1906,11 @@ _doc_api_script_upload = r"""
         are executed in separate threads and only thread-safe scripts should be uploaded
         in the background. **Developers of data acquisition workflows and/or user specific
         code are responsible for thread safety.**
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -1861,6 +1985,11 @@ _doc_api_function_execute = """
         ``user_group`` properties). The default user or user group name is used
         if the respective parameter is not specified or ``None``. The parameters are
         ignored by the HTTP version of the API.
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -2106,6 +2235,11 @@ _doc_api_re_pause = """
     option: str ('immediate' or 'deferred', optional)
         Pause the plan immediately (roll back to the previous checkpoint) or continue to
         the next checkpoint. Default: ``"deferred"``.
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
 
     Returns
     -------
@@ -2154,21 +2288,109 @@ _doc_api_re_pause = """
 _doc_api_re_resume = """
     Request Run Engine to resume paused plan. See documentation for ``re_pause`` API
     for more detailed information.
+
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
+
+    Returns
+    -------
+    dict
+        Dictionary keys:
+
+        - ``success``: *boolean* - success of the request.
+
+        - ``msg``: *str* - error message in case the request is rejected by RE Manager.
+
+    Raises
+    ------
+    RequestTimeoutError, RequestFailedError, RequestError, ClientError
+        All exceptions raised by ``send_request`` API.
 """
 
 _doc_api_re_stop = """
     Request Run Engine to stop paused plan. See documentation for ``re_pause`` API
     for more detailed information.
+
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
+
+    Returns
+    -------
+    dict
+        Dictionary keys:
+
+        - ``success``: *boolean* - success of the request.
+
+        - ``msg``: *str* - error message in case the request is rejected by RE Manager.
+
+    Raises
+    ------
+    RequestTimeoutError, RequestFailedError, RequestError, ClientError
+        All exceptions raised by ``send_request`` API.
 """
 
 _doc_api_re_abort = """
     Request Run Engine to abort paused plan. See documentation for ``re_pause`` API
     for more detailed information.
+
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
+
+    Returns
+    -------
+    dict
+        Dictionary keys:
+
+        - ``success``: *boolean* - success of the request.
+
+        - ``msg``: *str* - error message in case the request is rejected by RE Manager.
+
+    Raises
+    ------
+    RequestTimeoutError, RequestFailedError, RequestError, ClientError
+        All exceptions raised by ``send_request`` API.
 """
 
 _doc_api_re_halt = """
     Request Run Engine to halt paused plan. See documentation for ``re_pause`` API
     for more detailed information.
+
+    Parameters
+    ----------
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
+
+    Returns
+    -------
+    dict
+        Dictionary keys:
+
+        - ``success``: *boolean* - success of the request.
+
+        - ``msg``: *str* - error message in case the request is rejected by RE Manager.
+
+    Raises
+    ------
+    RequestTimeoutError, RequestFailedError, RequestError, ClientError
+        All exceptions raised by ``send_request`` API.
 """
 
 _doc_api_lock = """

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -294,47 +294,69 @@ class API_Threads_Mixin(API_Base):
     # =====================================================================================
     #                 API for monitoring and control of Queue
 
-    def item_add(self, item, *, pos=None, before_uid=None, after_uid=None, user=None, user_group=None):
+    def item_add(
+        self, item, *, pos=None, before_uid=None, after_uid=None, user=None, user_group=None, lock_key=None
+    ):
         # Docstring is maintained separately
         request_params = self._prepare_item_add(
-            item=item, pos=pos, before_uid=before_uid, after_uid=after_uid, user=user, user_group=user_group
+            item=item,
+            pos=pos,
+            before_uid=before_uid,
+            after_uid=after_uid,
+            user=user,
+            user_group=user_group,
+            lock_key=lock_key,
         )
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_add", params=request_params)
 
-    def item_add_batch(self, items, *, pos=None, before_uid=None, after_uid=None, user=None, user_group=None):
+    def item_add_batch(
+        self, items, *, pos=None, before_uid=None, after_uid=None, user=None, user_group=None, lock_key=None
+    ):
         # Docstring is maintained separately
         request_params = self._prepare_item_add_batch(
-            items=items, pos=pos, before_uid=before_uid, after_uid=after_uid, user=user, user_group=user_group
+            items=items,
+            pos=pos,
+            before_uid=before_uid,
+            after_uid=after_uid,
+            user=user,
+            user_group=user_group,
+            lock_key=lock_key,
         )
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_add_batch", params=request_params)
 
-    def item_update(self, item, *, replace=None, user=None, user_group=None):
+    def item_update(self, item, *, replace=None, user=None, user_group=None, lock_key=None):
         # Docstring is maintained separately
-        request_params = self._prepare_item_update(item=item, replace=replace, user=user, user_group=user_group)
+        request_params = self._prepare_item_update(
+            item=item, replace=replace, user=user, user_group=user_group, lock_key=lock_key
+        )
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_update", params=request_params)
 
-    def item_remove(self, *, pos=None, uid=None):
-        request_params = self._prepare_item_get_remove(pos=pos, uid=uid)
+    def item_remove(self, *, pos=None, uid=None, lock_key=None):
+        request_params = self._prepare_item_remove(pos=pos, uid=uid, lock_key=lock_key)
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_remove", params=request_params)
 
-    def item_remove_batch(self, *, uids, ignore_missing=None):
-        request_params = self._prepare_item_remove_batch(uids=uids, ignore_missing=ignore_missing)
+    def item_remove_batch(self, *, uids, ignore_missing=None, lock_key=None):
+        request_params = self._prepare_item_remove_batch(
+            uids=uids, ignore_missing=ignore_missing, lock_key=lock_key
+        )
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_remove_batch", params=request_params)
 
-    def item_move(self, *, pos=None, uid=None, pos_dest=None, before_uid=None, after_uid=None):
+    def item_move(self, *, pos=None, uid=None, pos_dest=None, before_uid=None, after_uid=None, lock_key=None):
         # Docstring is maintained separately
         request_params = self._prepare_item_move(
-            pos=pos, uid=uid, pos_dest=pos_dest, before_uid=before_uid, after_uid=after_uid
+            pos=pos, uid=uid, pos_dest=pos_dest, before_uid=before_uid, after_uid=after_uid, lock_key=lock_key
         )
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_move", params=request_params)
 
-    def item_move_batch(self, *, uids=None, pos_dest=None, before_uid=None, after_uid=None, reorder=None):
+    def item_move_batch(
+        self, *, uids=None, pos_dest=None, before_uid=None, after_uid=None, reorder=None, lock_key=None
+    ):
         # Docstring is maintained separately
         request_params = self._prepare_item_move_batch(
             uids=uids,
@@ -342,12 +364,13 @@ class API_Threads_Mixin(API_Base):
             before_uid=before_uid,
             after_uid=after_uid,
             reorder=reorder,
+            lock_key=lock_key,
         )
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_move_batch", params=request_params)
 
     def item_get(self, *, pos=None, uid=None):
-        request_params = self._prepare_item_get_remove(pos=pos, uid=uid)
+        request_params = self._prepare_item_get(pos=pos, uid=uid)
         return self.send_request(method="queue_item_get", params=request_params)
 
     def item_execute(self, item, *, user=None, user_group=None):
@@ -386,10 +409,11 @@ class API_Threads_Mixin(API_Base):
         self._clear_status_timestamp()
         return self.send_request(method="queue_stop_cancel")
 
-    def queue_clear(self):
+    def queue_clear(self, *, lock_key):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return self.send_request(method="queue_clear")
+        request_params = self._prepare_queue_clear(lock_key=lock_key)
+        return self.send_request(method="queue_clear", params=request_params)
 
     def queue_mode_set(self, **kwargs):
         # Docstring is maintained separately
@@ -419,10 +443,11 @@ class API_Threads_Mixin(API_Base):
             response = self._generate_response_history_get()
         return response
 
-    def history_clear(self):
+    def history_clear(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return self.send_request(method="history_clear")
+        request_params = self._prepare_history_clear(lock_key=lock_key)
+        return self.send_request(method="history_clear", params=request_params)
 
     def plans_allowed(self, *, reload=False, user_group=None):
         # Docstring is maintained separately
@@ -476,10 +501,10 @@ class API_Threads_Mixin(API_Base):
             response = self._generate_response_devices_existing()
         return response
 
-    def permissions_reload(self, *, restore_plans_devices=None, restore_permissions=None):
+    def permissions_reload(self, *, restore_plans_devices=None, restore_permissions=None, lock_key=None):
         # Docstring is maintained separately
         request_params = self._prepare_permissions_reload(
-            restore_plans_devices=restore_plans_devices, restore_permissions=restore_permissions
+            restore_plans_devices=restore_plans_devices, restore_permissions=restore_permissions, lock_key=lock_key
         )
         self._clear_status_timestamp()
         return self.send_request(method="permissions_reload", params=request_params)
@@ -488,9 +513,11 @@ class API_Threads_Mixin(API_Base):
         # Docstring is maintained separately
         return self.send_request(method="permissions_get")
 
-    def permissions_set(self, user_group_permissions):
+    def permissions_set(self, user_group_permissions, *, lock_key=None):
         # Docstring is maintained separately
-        request_params = self._prepare_permissions_set(user_group_permissions=user_group_permissions)
+        request_params = self._prepare_permissions_set(
+            user_group_permissions=user_group_permissions, lock_key=lock_key
+        )
         self._clear_status_timestamp()
         return self.send_request(method="permissions_set", params=request_params)
 

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -558,23 +558,25 @@ class API_Threads_Mixin(API_Base):
         self._clear_status_timestamp()
         return self.send_request(method="re_halt")
 
-    def lock(self, lock_key=None, *, environment=None, queue=None, note=None):
+    def lock(self, lock_key=None, *, environment=None, queue=None, note=None, user=None):
         # Docstring is maintained separately
-        request_params = self._prepare_lock(environment=environment, queue=queue, lock_key=lock_key, note=note)
+        request_params = self._prepare_lock(
+            environment=environment, queue=queue, lock_key=lock_key, note=note, user=user
+        )
         self._clear_status_timestamp()
         return self.send_request(method="lock", params=request_params)
 
-    def lock_environment(self, lock_key=None, *, note=None):
+    def lock_environment(self, lock_key=None, *, note=None, user=None):
         # Docstring is maintained separately
-        return self.lock(lock_key=lock_key, environment=True, note=note)
+        return self.lock(lock_key=lock_key, environment=True, note=note, user=user)
 
-    def lock_queue(self, lock_key=None, *, note=None):
+    def lock_queue(self, lock_key=None, *, note=None, user=None):
         # Docstring is maintained separately
-        return self.lock(lock_key=lock_key, queue=True, note=note)
+        return self.lock(lock_key=lock_key, queue=True, note=note, user=user)
 
-    def lock_all(self, lock_key=None, *, note=None):
+    def lock_all(self, lock_key=None, *, note=None, user=None):
         # Docstring is maintained separately
-        return self.lock(lock_key=lock_key, environment=True, queue=True, note=note)
+        return self.lock(lock_key=lock_key, environment=True, queue=True, note=note, user=user)
 
     def lock_info(self, lock_key=None, *, reload=False):
         # Docstring is maintained separately

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -47,6 +47,12 @@ from .api_docstrings import (
     _doc_api_re_stop,
     _doc_api_re_abort,
     _doc_api_re_halt,
+    _doc_api_lock,
+    _doc_api_lock_environment,
+    _doc_api_lock_queue,
+    _doc_api_lock_all,
+    _doc_api_lock_info,
+    _doc_api_unlock,
 )
 
 
@@ -684,3 +690,9 @@ API_Threads_Mixin.re_resume.__doc__ = _doc_api_re_resume
 API_Threads_Mixin.re_stop.__doc__ = _doc_api_re_stop
 API_Threads_Mixin.re_abort.__doc__ = _doc_api_re_abort
 API_Threads_Mixin.re_halt.__doc__ = _doc_api_re_halt
+API_Threads_Mixin.lock.__doc__ = _doc_api_lock
+API_Threads_Mixin.lock_environment.__doc__ = _doc_api_lock_environment
+API_Threads_Mixin.lock_queue.__doc__ = _doc_api_lock_queue
+API_Threads_Mixin.lock_all.__doc__ = _doc_api_lock_all
+API_Threads_Mixin.lock_info.__doc__ = _doc_api_lock_info
+API_Threads_Mixin.unlock.__doc__ = _doc_api_unlock

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -415,7 +415,7 @@ class API_Threads_Mixin(API_Base):
         request_params = self._prepare_environment_control(lock_key=lock_key)
         return self.send_request(method="queue_stop_cancel", params=request_params)
 
-    def queue_clear(self, *, lock_key):
+    def queue_clear(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
         request_params = self._prepare_queue_clear(lock_key=lock_key)

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -373,41 +373,47 @@ class API_Threads_Mixin(API_Base):
         request_params = self._prepare_item_get(pos=pos, uid=uid)
         return self.send_request(method="queue_item_get", params=request_params)
 
-    def item_execute(self, item, *, user=None, user_group=None):
+    def item_execute(self, item, *, user=None, user_group=None, lock_key=None):
         # Docstring is maintained separately
-        request_params = self._prepare_item_execute(item=item, user=user, user_group=user_group)
+        request_params = self._prepare_item_execute(item=item, user=user, user_group=user_group, lock_key=lock_key)
         self._clear_status_timestamp()
         return self.send_request(method="queue_item_execute", params=request_params)
 
-    def environment_open(self):
+    def environment_open(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return self.send_request(method="environment_open")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return self.send_request(method="environment_open", params=request_params)
 
-    def environment_close(self):
+    def environment_close(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return self.send_request(method="environment_close")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return self.send_request(method="environment_close", params=request_params)
 
-    def environment_destroy(self):
+    def environment_destroy(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return self.send_request(method="environment_destroy")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return self.send_request(method="environment_destroy", params=request_params)
 
-    def queue_start(self):
+    def queue_start(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return self.send_request(method="queue_start")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return self.send_request(method="queue_start", params=request_params)
 
-    def queue_stop(self):
+    def queue_stop(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return self.send_request(method="queue_stop")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return self.send_request(method="queue_stop", params=request_params)
 
-    def queue_stop_cancel(self):
+    def queue_stop_cancel(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return self.send_request(method="queue_stop_cancel")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return self.send_request(method="queue_stop_cancel", params=request_params)
 
     def queue_clear(self, *, lock_key):
         # Docstring is maintained separately
@@ -521,18 +527,22 @@ class API_Threads_Mixin(API_Base):
         self._clear_status_timestamp()
         return self.send_request(method="permissions_set", params=request_params)
 
-    def script_upload(self, script, *, update_lists=None, update_re=None, run_in_background=None):
+    def script_upload(self, script, *, update_lists=None, update_re=None, run_in_background=None, lock_key=None):
         # Docstring is maintained separately
         request_params = self._prepare_script_upload(
-            script=script, update_lists=update_lists, update_re=update_re, run_in_background=run_in_background
+            script=script,
+            update_lists=update_lists,
+            update_re=update_re,
+            run_in_background=run_in_background,
+            lock_key=lock_key,
         )
         self._clear_status_timestamp()
         return self.send_request(method="script_upload", params=request_params)
 
-    def function_execute(self, item, *, run_in_background=None, user=None, user_group=None):
+    def function_execute(self, item, *, run_in_background=None, user=None, user_group=None, lock_key=None):
         # Docstring is maintained separately
         request_params = self._prepare_function_execute(
-            item=item, run_in_background=run_in_background, user=user, user_group=user_group
+            item=item, run_in_background=run_in_background, user=user, user_group=user_group, lock_key=lock_key
         )
         self._clear_status_timestamp()
         return self.send_request(method="function_execute", params=request_params)
@@ -559,31 +569,35 @@ class API_Threads_Mixin(API_Base):
             response = self._generate_response_re_runs(option=option)
         return response
 
-    def re_pause(self, option=None):
+    def re_pause(self, option=None, *, lock_key=None):
         # Docstring is maintained separately
-        request_params = self._prepare_re_pause(option=option)
+        request_params = self._prepare_re_pause(option=option, lock_key=lock_key)
         self._clear_status_timestamp()
         return self.send_request(method="re_pause", params=request_params)
 
-    def re_resume(self):
+    def re_resume(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return self.send_request(method="re_resume")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return self.send_request(method="re_resume", params=request_params)
 
-    def re_stop(self):
+    def re_stop(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return self.send_request(method="re_stop")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return self.send_request(method="re_stop", params=request_params)
 
-    def re_abort(self):
+    def re_abort(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return self.send_request(method="re_abort")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return self.send_request(method="re_abort", params=request_params)
 
-    def re_halt(self):
+    def re_halt(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        return self.send_request(method="re_halt")
+        request_params = self._prepare_environment_control(lock_key=lock_key)
+        return self.send_request(method="re_halt", params=request_params)
 
     def lock(self, lock_key=None, *, environment=None, queue=None, note=None, user=None):
         # Docstring is maintained separately

--- a/bluesky_queueserver_api/comm_base.py
+++ b/bluesky_queueserver_api/comm_base.py
@@ -57,6 +57,9 @@ rest_api_method_map = {
     "function_execute": ("POST", "/api/function/execute"),
     "task_status": ("GET", "/api/task/status"),
     "task_result": ("GET", "/api/task/result"),
+    "lock": ("POST", "/api/lock"),
+    "unlock": ("POST", "/api/unlock"),
+    "lock_info": ("GET", "/api/lock/info"),
     "manager_stop": ("POST", "/api/manager/stop"),
     "manager_kill": ("POST", "/api/test/manager/kill"),
 }

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -3517,10 +3517,9 @@ def test_lock_key_1(library, protocol):
     (True, True),
 ])
 @pytest.mark.parametrize("library", ["THREADS", "ASYNC"])
-# @pytest.mark.parametrize("protocol", ["ZMQ", "HTTP"])
-@pytest.mark.parametrize("protocol", ["ZMQ"])
+@pytest.mark.parametrize("protocol", ["ZMQ", "HTTP"])
 # fmt: on
-def test_lock_1(re_manager, library, protocol, use_current_lock_key, set_note):  # noqa: F811
+def test_lock_1(re_manager, fastapi_server, library, protocol, use_current_lock_key, set_note):  # noqa: F811
     """
     ``lock``, ``lock_environment``, ``lock_queue``, ``lock_all``, ``unlock``, ``lock_info``: basic tests
     Call the API with all valid combinations of parameters.
@@ -3617,10 +3616,9 @@ def test_lock_1(re_manager, library, protocol, use_current_lock_key, set_note): 
 
 
 @pytest.mark.parametrize("library", ["THREADS", "ASYNC"])
-# @pytest.mark.parametrize("protocol", ["ZMQ", "HTTP"])
-@pytest.mark.parametrize("protocol", ["ZMQ"])
+@pytest.mark.parametrize("protocol", ["ZMQ", "HTTP"])
 # fmt: on
-def test_lock_2(re_manager, library, protocol):  # noqa: F811
+def test_lock_2(re_manager, fastapi_server, library, protocol):  # noqa: F811
     """
     ``lock``, ``lock_environment``, ``lock_queue``, ``lock_all``, ``unlock``, ``lock_info``:
     Test some edge cases and invalid parameter values.

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -3952,8 +3952,7 @@ def test_zmq_api_lock_4(
     ({"environment": True}, True),  # Queue is locked
     ({"environment": True, "queue": True}, True),  # Queue is locked
 ])
-# @pytest.mark.parametrize("library", ["THREADS", "ASYNC"])
-@pytest.mark.parametrize("library", ["ASYNC"])
+@pytest.mark.parametrize("library", ["THREADS", "ASYNC"])
 @pytest.mark.parametrize("protocol", ["ZMQ", "HTTP"])
 # fmt: on
 def test_zmq_api_lock_5(

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -154,6 +154,26 @@ API for Controlling RE History
     zmq.REManagerAPI.history_get
     zmq.REManagerAPI.history_clear
 
+API for Locking RE Manager
+**************************
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated
+
+    zmq.REManagerAPI.lock
+    zmq.REManagerAPI.lock_environment
+    zmq.REManagerAPI.lock_queue
+    zmq.REManagerAPI.lock_all
+    zmq.REManagerAPI.unlock
+    zmq.REManagerAPI.lock_info
+    zmq.REManagerAPI.lock_key
+    zmq.REManagerAPI.enable_locked_api
+    zmq.REManagerAPI.get_default_lock_key
+    zmq.REManagerAPI.set_default_lock_key
+    zmq.REManagerAPI.default_lock_key_path
+
+
 API for Executing Tasks
 ***********************
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Completed work on the API for locking RE Manager started in https://github.com/bluesky/bluesky-queueserver-api/pull/23.
Now the API are fully functional, documented and tested. The new parameter ``lock_key`` is added to all lockable API.
