### PR TITLE
Minor fix in the docstring for 'REManagerAPI.lock'

### DIFF
--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -2620,7 +2620,7 @@ _doc_api_lock = """
             print(f"API call failed: {ex}")
 
         # If locked API are enabled, then the current lock key is sent with each API request.
-        RM.enable_locked_api()
+        RM.enable_locked_api = True
 
         RM.environment_open()  # API call is expected to succeed.
         # await RM.environment_open()


### PR DESCRIPTION
Minor fix in the example included in the docstring for `REManagerAPI.lock()`