### PR TITLE
add happi support

### DIFF
--- a/bluesky_queueserver_api/_happi.py
+++ b/bluesky_queueserver_api/_happi.py
@@ -1,0 +1,28 @@
+"""Support for happi -
+pcdshub.github.io/happi
+"""
+
+
+import re
+import copy
+
+from happi.item import HappiItem, EntryInfo  # type: ignore
+
+
+class REManagerAPIZMQItem(HappiItem):
+    zmq_control_addr = EntryInfo("ZMQ control address.", enforce=str, optional=False)
+    zmq_info_addr = EntryInfo("ZMQ info address.", enforce=str, optional=False)
+    kwargs = copy.copy(HappiItem.kwargs)
+    kwargs.default = {"zmq_control_addr": "{{zmq_control_addr}}",
+                      "zmq_info_addr": "{{zmq_info_addr}}"}
+    device_class = EntryInfo(default="bluesky_queueserver_api.zmq.REManagerAPI")
+
+
+class REManagerAPIHTTPItem(HappiItem):
+    http_server_uri = EntryInfo("HTTP server URI.", enforce=str, optional=False)
+    http_auth_provider = EntryInfo("HTTP auth provider.", enforce=str, optional=False)
+    kwargs = copy.copy(HappiItem.kwargs)
+    kwargs.default = {"http_server_uri": "{{http_server_uri}}",
+                      "http_auth_provider": "{{http_auth_provider}}"}
+    device_class = EntryInfo(default="bluesky_queueserver_api.http.REManagerAPI")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # List required packages in this file, one per line.
 bluesky-queueserver
 httpx
+happi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adding happi support for REManagerAPI objects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

End users can find it cumbersome to manually create REManagerAPI objects due to esoteric (to them) arguments. Happi allows them to grab such objects quickly. Happi is familiar to users who are already using it for device management.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Added
- REManagerAPI objects can now be managed by happi.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No tests.

<!--
## Screenshots (if appropriate):
-->
