### PR TITLE
Rename the default user group from 'admin' to 'primary'

### DIFF
--- a/bluesky_queueserver_api/_defaults.py
+++ b/bluesky_queueserver_api/_defaults.py
@@ -16,3 +16,6 @@ default_http_login_timeout = 60.0  # s
 default_http_server_uri = "http://localhost:60610"  # Default URI (for testing and evaluation)
 
 default_wait_timeout = 600  # Timeout for wait operations in seconds
+
+default_user_name = "Queue Server API User"
+default_user_group = "primary"

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -63,8 +63,6 @@ class API_Async_Mixin(API_Base):
             status_expiration_period=status_expiration_period, status_polling_period=status_polling_period
         )
 
-        self._is_closing = False
-
         self._event_status_get = asyncio.Event()
         self._status_get_cb = []  # A list of callbacks
         self._status_get_cb_lock = asyncio.Lock()
@@ -276,12 +274,6 @@ class API_Async_Mixin(API_Base):
             raise _ex
         else:
             return _status
-
-    def _close_api(self):
-        self._is_closing = True  # Exit all tasks
-
-    def __del__(self):
-        self._close_api()
 
     # =====================================================================================
     #                 API for monitoring and control of RE Manager

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -8,6 +8,7 @@ import time as ttime
 
 from .item import BItem
 from .comm_base import RequestParameterError
+from ._defaults import default_user_name, default_user_group
 
 
 class WaitTimeoutError(TimeoutError):
@@ -174,8 +175,8 @@ class API_Base:
         self._status_current = None
         self._status_exception = None
 
-        self._user = "Queue Server API User"  # Meaningful user name should be set in application code.
-        self._user_group = "admin"
+        self._user = default_user_name  # Meaningful user name should be set in application code.
+        self._user_group = default_user_group
 
         self._current_plan_queue = []
         self._current_running_item = {}

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -63,8 +63,6 @@ class API_Threads_Mixin(API_Base):
             status_expiration_period=status_expiration_period, status_polling_period=status_polling_period
         )
 
-        self._is_closing = False
-
         self._event_status_get = threading.Event()
         self._status_get_cb = []  # A list of callbacks for requests to get status
         self._wait_cb = []  # A list of callbacks for 'wait' API
@@ -271,12 +269,6 @@ class API_Threads_Mixin(API_Base):
             raise _ex
         else:
             return _status
-
-    def _close_api(self):
-        self._is_closing = True  # Exit all daemon threads
-
-    def __del__(self):
-        self._close_api()
 
     # =====================================================================================
     #                 API for monitoring and control of RE Manager

--- a/bluesky_queueserver_api/comm_async.py
+++ b/bluesky_queueserver_api/comm_async.py
@@ -42,8 +42,12 @@ class ReManagerComm_ZMQ_Async(ReManagerAPI_ZMQ_Base):
         return response
 
     async def close(self):
+        self._is_closing = True
         await self._console_monitor.disable_wait(timeout=self._console_monitor_poll_timeout * 10)
         self._client.close()
+
+    def __del__(self):
+        self._is_closing = True
 
 
 class ReManagerComm_HTTP_Async(ReManagerAPI_HTTP_Base):
@@ -116,10 +120,6 @@ class ReManagerComm_HTTP_Async(ReManagerAPI_HTTP_Base):
 
         return response
 
-    async def close(self):
-        await self._console_monitor.disable_wait(timeout=self._console_monitor_poll_period * 10)
-        await self._client.aclose()
-
     async def login(self, username=None, *, password=None, provider=None):
         # Docstring is maintained separately
         endpoint, data = self._prepare_login(username=username, password=password, provider=provider)
@@ -133,6 +133,14 @@ class ReManagerComm_HTTP_Async(ReManagerAPI_HTTP_Base):
         response = await self.send_request(method="session_refresh", params={"refresh_token": refresh_token})
         response = self._process_login_response(response=response)
         return response
+
+    async def close(self):
+        self._is_closing = True
+        await self._console_monitor.disable_wait(timeout=self._console_monitor_poll_period * 10)
+        await self._client.aclose()
+
+    def __del__(self):
+        self._is_closing = True
 
 
 ReManagerComm_ZMQ_Async.send_request.__doc__ = _doc_send_request

--- a/bluesky_queueserver_api/comm_base.py
+++ b/bluesky_queueserver_api/comm_base.py
@@ -133,6 +133,8 @@ class ReManagerAPI_Base:
         self._protocol = None
         self._pass_user_info = True
 
+        self._is_closing = False  # Set True to exit all background tasks.
+
     @property
     def request_fail_exceptions_enabled(self):
         """

--- a/bluesky_queueserver_api/comm_threads.py
+++ b/bluesky_queueserver_api/comm_threads.py
@@ -42,8 +42,12 @@ class ReManagerComm_ZMQ_Threads(ReManagerAPI_ZMQ_Base):
         return response
 
     def close(self):
+        self._is_closing = True
         self._console_monitor.disable_wait(timeout=self._console_monitor_poll_timeout * 10)
         self._client.close()
+
+    def __del__(self):
+        self._is_closing = True
 
 
 class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
@@ -116,10 +120,6 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
 
         return response
 
-    def close(self):
-        self._console_monitor.disable_wait(timeout=self._console_monitor_poll_period * 10)
-        self._client.close()
-
     def login(self, username=None, *, password=None, provider=None):
         # Docstring is maintained separately
         endpoint, data = self._prepare_login(username=username, password=password, provider=provider)
@@ -137,6 +137,14 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         )
         response = self._process_login_response(response=response)
         return response
+
+    def close(self):
+        self._is_closing = True
+        self._console_monitor.disable_wait(timeout=self._console_monitor_poll_period * 10)
+        self._client.close()
+
+    def __del__(self):
+        self._is_closing = True
 
 
 ReManagerComm_ZMQ_Threads.send_request.__doc__ = _doc_send_request

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -13,6 +13,9 @@ from .common import fastapi_server, fastapi_server_fs  # noqa: F401
 from .common import _is_async, _select_re_manager_api, instantiate_re_api_class
 
 from bluesky_queueserver_api import BPlan, BFunc, WaitMonitor
+from bluesky_queueserver_api._defaults import default_user_group
+
+_user, _user_group = "Test User", default_user_group
 
 _plan1 = {"name": "count", "args": [["det1", "det2"]], "item_type": "plan"}
 
@@ -33,7 +36,7 @@ def test_instantiation_01(re_manager, fastapi_server, protocol, library):  # noq
         RM = instantiate_re_api_class(rm_api_class)
         assert RM.protocol == RM.Protocols(protocol)
         assert RM.user == user_name
-        assert RM.user_group == "admin"
+        assert RM.user_group == default_user_group
 
         RM.set_user_name_to_login_name()
         assert RM.user == user_name_2
@@ -50,7 +53,7 @@ def test_instantiation_01(re_manager, fastapi_server, protocol, library):  # noq
             RM = instantiate_re_api_class(rm_api_class)
             assert RM.protocol == RM.Protocols(protocol)
             assert RM.user == user_name
-            assert RM.user_group == "admin"
+            assert RM.user_group == default_user_group
 
             RM.set_user_name_to_login_name()
             assert RM.user == user_name_2
@@ -115,8 +118,6 @@ def test_status_02(re_manager, fastapi_server, protocol, library, reload):  # no
     In a rapid sequence: read status, add item to queue (using low-level API), read status again.
     Verify if the status was reloaded if ``reload`` is ``True``.
     """
-
-    _user, _user_group = "Test User", "admin"
 
     rm_api_class = _select_re_manager_api(protocol, library)
     status_params = {"reload": reload} if (reload is not None) else {}
@@ -1835,7 +1836,7 @@ def test_permissions_get_set_01(re_manager, fastapi_server, protocol, library): 
         permissions = resp1["user_group_permissions"]
 
         # Remove allowed plans (list of allowed plans should be empty)
-        del permissions["user_groups"]["admin"]["allowed_plans"]
+        del permissions["user_groups"][_user_group]["allowed_plans"]
 
         resp2 = RM.plans_allowed()
         assert resp2["success"] is True
@@ -1883,7 +1884,7 @@ def test_permissions_get_set_01(re_manager, fastapi_server, protocol, library): 
             permissions = resp1["user_group_permissions"]
 
             # Remove allowed plans (list of allowed plans should be empty)
-            del permissions["user_groups"]["admin"]["allowed_plans"]
+            del permissions["user_groups"][_user_group]["allowed_plans"]
 
             resp2 = await RM.plans_allowed()
             assert resp2["success"] is True

--- a/bluesky_queueserver_api/tests/test_api_fs.py
+++ b/bluesky_queueserver_api/tests/test_api_fs.py
@@ -305,9 +305,14 @@ authentication:
                   alice: alice_password
                   bob: bob_password
                   cara: cara_password
-    qserver_admins:
-        - provider: toy
-          id: alice
+api_access:
+    policy: bluesky_httpserver.authorization:DictionaryAPIAccessControl
+    args:
+        users:
+            bob:
+                roles: 
+                    - admin
+                    - expert
 """
 
 
@@ -325,12 +330,17 @@ authentication:
                   alice: alice_password
                   bob: bob_password
                   cara: cara_password
-    qserver_admins:
-        - provider: toy
-          id: alice
     access_token_max_age: 2
     refresh_token_max_age: 600
     session_max_age: 1000
+api_access:
+    policy: bluesky_httpserver.authorization:DictionaryAPIAccessControl
+    args:
+        users:
+            bob:
+                roles: 
+                    - admin
+                    - expert
 """
 
 

--- a/bluesky_queueserver_api/tests/test_api_fs.py
+++ b/bluesky_queueserver_api/tests/test_api_fs.py
@@ -310,7 +310,7 @@ api_access:
     args:
         users:
             bob:
-                roles: 
+                roles:
                     - admin
                     - expert
 """
@@ -338,7 +338,7 @@ api_access:
     args:
         users:
             bob:
-                roles: 
+                roles:
                     - admin
                     - expert
 """

--- a/bluesky_queueserver_api/tests/test_comm.py
+++ b/bluesky_queueserver_api/tests/test_comm.py
@@ -7,7 +7,7 @@ from bluesky_queueserver import generate_zmq_keys
 from bluesky_queueserver_api.comm_base import ReManagerAPI_Base
 from bluesky_queueserver_api.comm_threads import ReManagerComm_ZMQ_Threads, ReManagerComm_HTTP_Threads
 from bluesky_queueserver_api.comm_async import ReManagerComm_ZMQ_Async, ReManagerComm_HTTP_Async
-from bluesky_queueserver_api._defaults import default_http_server_uri
+from bluesky_queueserver_api._defaults import default_http_server_uri, default_user_group
 
 from .common import re_manager, re_manager_cmd  # noqa: F401
 from .common import fastapi_server  # noqa: F401
@@ -15,7 +15,7 @@ from .common import set_qserver_zmq_address, set_qserver_zmq_public_key, API_KEY
 
 _plan1 = {"name": "count", "args": [["det1", "det2"]], "item_type": "plan"}
 _user = "Test User"
-_user_group = "admin"
+_user_group = default_user_group
 
 
 def test_ReManagerAPI_Base_01():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The changes include:

- The default user group is renamed from 'admin' to 'primary' (see https://github.com/bluesky/bluesky-queueserver/pull/259).
- Unit tests are modified to work with updated HTTP Server (see https://github.com/bluesky/bluesky-httpserver/pull/39).

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

- Default user group is renamed from 'admin' to 'primary'. Rename the user group in 'user_group_permissions.yaml' if the workflow depends on the default user group name.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
