### PR TITLE
Implementation of additional REST API for authorization

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
       fail-fast: false
 
     env:

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -2952,7 +2952,7 @@ _doc_api_session_revoke = """
     Examples
     --------
 
-    Log into the server, find UID of a session and revoke the session.
+    Log into the server, find UID of a session and revoke the session::
 
         RM.login("bob", password="bob_password")
         result = RM.whoami()
@@ -3020,7 +3020,7 @@ _doc_api_session_revoke = """
     Returns
     -------
     dict
-        Returns the dictionary ``{'success': True, 'msg': ''}`` if success.
+        Returns the dictionary ``{'success': True, 'msg': ''}`` in case of success.
 
     Raises
     ------
@@ -3154,7 +3154,7 @@ _doc_api_apikey_delete = """
     Returns
     -------
     dict
-        Returns the dictionary ``{'success': True, 'msg': ''}`` if success.
+        Returns the dictionary ``{'success': True, 'msg': ''}`` in case of success.
 
     Raises
     ------

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -2939,3 +2939,402 @@ _doc_api_session_refresh = """
     HTTPRequestError, HTTPClientError, HTTPServerError
         Error while sending and processing HTTP request.
 """
+
+_doc_api_session_revoke = """
+    Revoke session for an authorized user. If the session is revoked, the respective refresh
+    token can no longer be used to refresh session. Access tokens and API keys will continue
+    working. By default the API request is authorized using the default authorization key
+    (set using ``set_authorization_key()`` or as a result of login). A token or an API key
+    passed as a parameter override the default authorization key, which allows to revoke
+    sessions for different users without changing the default authorization key (without
+    logging out).
+
+    Examples
+    --------
+
+    Log into the server, find UID of a session and revoke the session.
+
+        RM.login("bob", password="bob_password")
+        result = RM.whoami()
+
+        # {'uuid': '352cae89-7e94-45be-a405-c39099ebe515',
+        #  'type': 'user',
+        #  'identities': [
+        #     {'id': 'bob',
+        #       'provider': 'toy',
+        #       'latest_login': '2022-10-02T02:47:57'}],
+        #   'api_keys': [],
+        #   'sessions': [{'uuid': 'e544d4b6-4750-43c3-8ba0-b7e9aedd2045',
+        #                 'expiration_time': '2023-10-01T19:28:15',
+        #                 'revoked': False},
+        #                {'uuid': '66ee49c1-32b4-4778-8502-205e35151736',
+        #                 'expiration_time': '2023-10-01T19:30:03',
+        #                 'revoked': False},
+        #       .....................................................
+        #                {'uuid': 'c41d2f01-607e-49c0-9b3e-a93c383330c0',
+        #                 'expiration_time': '2023-10-02T02:47:57',
+        #                 'revoked': False}],
+        #   'latest_activity': '2022-10-02T02:47:57',
+        #   'roles': [],
+        #   'scopes': [],
+        #   'api_key_scopes': None}
+
+        # Let's revoke session "e544d4b6-4750-43c3-8ba0-b7e9aedd2045"
+        RM.session_revoke(session_uid="e544d4b6-4750-43c3-8ba0-b7e9aedd2045")
+
+        result = RM.whoami()
+
+        # NOTE: the session is now labeled as revoked ("revoked": True)
+        # {'uuid': '352cae89-7e94-45be-a405-c39099ebe515',
+        #  'type': 'user',
+        #  'identities': [
+        #     {'id': 'bob',
+        #       'provider': 'toy',
+        #       'latest_login': '2022-10-02T02:47:57'}],
+        #   'api_keys': [],
+        #   'sessions': [{'uuid': 'e544d4b6-4750-43c3-8ba0-b7e9aedd2045',
+        #                 'expiration_time': '2023-10-01T19:28:15',
+        #                 'revoked': True},
+        #                {'uuid': '66ee49c1-32b4-4778-8502-205e35151736',
+        #                 'expiration_time': '2023-10-01T19:30:03',
+        #                 'revoked': False},
+        #       .....................................................
+        #                {'uuid': 'c41d2f01-607e-49c0-9b3e-a93c383330c0',
+        #                 'expiration_time': '2023-10-02T02:47:57',
+        #                 'revoked': False}],
+        #   'latest_activity': '2022-10-02T02:47:57',
+        #   'roles': [],
+        #   'scopes': [],
+        #   'api_key_scopes': None}
+
+    Parameters
+    ----------
+    session_uid: str
+        Full session UID. Session UID may be obtained from results returned by
+        ``REManagerAPI.whoami()`` or ``REManagerAPI.principal_info()``.
+    token, api_key: str or None, optional
+        Access token or an API key. The parameters are mutually exclusive: the API fails
+        if both parameters are not *None*. A token or an API key overrides the default
+        authentication key. Default: *None*.
+
+    Returns
+    -------
+    dict
+        Returns the dictionary ``{'success': True, 'msg': ''}`` if success.
+
+    Raises
+    ------
+    RequestParameterError
+        Incorrect or insufficient parameters in the API call.
+    HTTPRequestError, HTTPClientError, HTTPServerError
+        Error while sending and processing HTTP request.
+"""
+
+_doc_api_apikey_new = """
+    Generate a new API key for authorized user. The API request is authorized using the
+    default security key (set using ``set_authorization_key()`` or as a result of login).
+
+    Users with administrative privileges can generate API keys for other users based on
+    principal UID. Principal UID may be found using ``REManagerAPI.whoami()`` or
+    ``REManagerAPI.principal_info()``.
+
+    Examples
+    --------
+    Log into the server and create an API key, which inherits the scopes from principal::
+
+        RM.login("bob", password="bob_password")
+        result = RM.apikey_new(expires_in=900)
+
+        # {'first_eight': '66ccb3ca',
+        #  'expiration_time': '2022-10-02T03:29:20',
+        #  'note': None,
+        #  'scopes': ['inherit'],
+        #  'latest_activity': None,
+        #  'secret': '66ccb3ca33ea091ab297331ba2589bdcf7ea9f5f168dbfd90c156652d1cedd9533c1bc59'}
+
+    Parameters
+    ----------
+    expires_in: int
+        Duration of API lifetime in seconds. Lifetime must be positive non-zero integer.
+    scopes: list(str) or None, optional
+        Optional list of scopes, such as ``["read:status", "read:queue", "user:apikeys"]``.
+        If the value is ``None`` (default), then the new API inherits the allowed scopes
+        of the principal (if authorized with token) or the original API key (if authorized
+        with API key). Default: *None*.
+    note: str or None, optional
+        Optional note. Default: *None*.
+    principal_uid: str or None, optional
+        Principal UID of a user. Including principal UID allows to create API keys
+        for any user registered in the database (user who logged into the server at least
+        once). This operation requires administrative privileges. The API fails if
+        ``principal_uid`` is not *None* and authorization is performed with security key
+        that does not have administrative privileges. Default: *None*.
+
+    Returns
+    -------
+    dict
+        The API key is returned as ``'secret'`` key of the dictionary.
+
+    Raises
+    ------
+    RequestParameterError
+        Incorrect or insufficient parameters in the API call.
+    HTTPRequestError, HTTPClientError, HTTPServerError
+        Error while sending and processing HTTP request.
+"""
+
+_doc_api_apikey_info = """
+    Get information about an API key. The API returning information about the API
+    key used to authorize the request. The request fails if a token is used for
+    authorization. If the parameter ``api_key`` is *None*, then the default
+    security key (set by ``REManagerAPI.set_authorization_key()`` and must be
+    an API key, not a token) is used. The API key passed with the parameter ``api_key``
+    override the default security key (the default is ignored). This allows to
+    obtain information on any API key without logging out or changing
+    the default security key.
+
+    Examples
+    --------
+    Log into the server, generate an API key and get the information on the generated
+    API key::
+
+        RM.login("bob", password="bob_password")
+        result_key = RM.apikey_new(expires_in=900)
+
+        # {'first_eight': '48b27a85',
+        #  'expiration_time': '2022-10-02T14:35:59',
+        #  'note': None,
+        #  'scopes': ['inherit'],
+        #  'latest_activity': None,
+        #  'secret': '48b27a85b71946f7840c6d708dd49a42c8945d8cb36b9bb378a3d93d1e1bd586c5851b84'}
+
+        result = RM.apikey_info(api_key=result_key["secret"]
+
+        # {'first_eight': '48b27a85',
+        #  'expiration_time': '2022-10-02T14:35:59',
+        #  'note': None,
+        #  'scopes': ['inherit'],
+        #  'latest_activity': None}
+
+    Parameters
+    ----------
+    api_key: str or None, optional
+        API key of interest. The parameter is used for authorization of the request
+        instead of the default security key, which is ignored. Default: ``None``.
+
+    Raises
+    ------
+    RequestParameterError
+        Incorrect or insufficient parameters in the API call.
+    HTTPRequestError, HTTPClientError, HTTPServerError
+        Error while sending and processing HTTP request.
+"""
+
+_doc_api_apikey_delete = """
+    Delete an API key for the authorized principal. The API key is identified by
+    first eight characters. For example, an API key ::
+
+        66ccb3ca33ea091ab297331ba2589bdcf7ea9f5f168dbfd90c156652d1cedd9533c1bc59
+
+    is identified as ``66ccb3ca``. The request is authorized using the default
+    security key (set by ``REManagerAPI.set_authorization_key()`` or as a result of
+    login). Alternatively, a different authorization key (an access token or an API key)
+    can be passed as a parameter. This allows to delete API keys for other prinicipals
+    without logging out or changing the default authorization key.
+
+    Parameters
+    ----------
+    first_eight: str
+        First eight characters of the API key.
+    token, api_key: str or None, optional
+        Access token or an API key. The parameters are mutually exclusive: the API fails
+        if both parameters are not *None*. A token or an API key overrides the default
+        authentication key. Default: *None*.
+
+    Returns
+    -------
+    dict
+        Returns the dictionary ``{'success': True, 'msg': ''}`` if success.
+
+    Raises
+    ------
+    RequestParameterError
+        Incorrect or insufficient parameters in the API call.
+    HTTPRequestError, HTTPClientError, HTTPServerError
+        Error while sending and processing HTTP request.
+"""
+
+_doc_api_whoami = """
+    Returns full information about the principal. The principal is identified based
+    on the default authorization key (set by ``REManagerAPI.set_authorization_key()``
+    or as a result of login) or the token or the API key passed as parameters.
+    The returned information includes the list of identities, API keys and sessions
+    for the principal.
+
+    Examples
+    --------
+    Log into the server and call ``REManagerAPI.whoami()``::
+
+        RM.login("bob", password="bob_password")
+        result = RM.whoami()
+
+        # {'uuid': '352cae89-7e94-45be-a405-c39099ebe515',
+        #  'type': 'user',
+        #  'identities': [
+        #     {'id': 'bob',
+        #       'provider': 'toy',
+        #       'latest_login': '2022-10-02T02:47:57'}],
+        #   'api_keys': [],
+        #   'sessions': [{'uuid': 'e544d4b6-4750-43c3-8ba0-b7e9aedd2045',
+        #                 'expiration_time': '2023-10-01T19:28:15',
+        #                 'revoked': False},
+        #                {'uuid': '66ee49c1-32b4-4778-8502-205e35151736',
+        #                 'expiration_time': '2023-10-01T19:30:03',
+        #                 'revoked': False},
+        #       .....................................................
+        #                {'uuid': 'c41d2f01-607e-49c0-9b3e-a93c383330c0',
+        #                 'expiration_time': '2023-10-02T02:47:57',
+        #                 'revoked': False}],
+        #   'latest_activity': '2022-10-02T02:47:57',
+        #   'roles': [],
+        #   'scopes': [],
+        #   'api_key_scopes': None}
+
+    Parameters
+    ----------
+    token, api_key: str or None, optional
+        Access token or an API key. The parameters are mutually exclusive: the API fails
+        if both parameters are not *None*. A token or an API key overrides the default
+        authentication key. Default: *None*.
+
+    Returns
+    -------
+    dict
+        Information on the authorized principal. See the example in the API description.
+
+    Raises
+    ------
+    RequestParameterError
+        Incorrect or insufficient parameters in the API call.
+    HTTPRequestError, HTTPClientError, HTTPServerError
+        Error while sending and processing HTTP request.
+"""
+
+_doc_api_principal_info = """
+    Returns full information on all principals or one principal. The principal
+    information is a dictionary, which is identical to the dictionary returned by
+    ``REManagerAPI.whoami()``. If the ``principal_uid`` is not specified or ``None``,
+    then the list of dictionaries for all principals is returned.
+
+    The client must have administrative privileges to use this API.
+
+    Parameters
+    ----------
+    principal_uid: str or None, optional
+        Principal UID.
+
+    Returns
+    -------
+    dict or list(dict)
+        A dictionary with information on the selected principal or a list of
+        dictionaries with information on all principals.
+
+    Raises
+    ------
+    RequestParameterError
+        Incorrect or insufficient parameters in the API call.
+    HTTPRequestError, HTTPClientError, HTTPServerError
+        Error while sending and processing HTTP request.
+"""
+
+_doc_api_api_scopes = """
+    Returns API scopes for an authorized user. Authorization is performed using
+    the default authorization key (set using ``REManagerAPI.set_authorization_key()``
+    or as a result of login) or an access token or an API key passed as parameters.
+    The API returns the exact list scopes that is currently used by the server for
+    validating access permissions for the token or the API key used for authorization.
+    In addition, the API returns a list of roles for the authorized user.
+    The returned scopes are always a subset of combined scopes of the roles.
+
+    Examples
+    --------
+    Log into the server and get the scopes::
+
+        RM.login("bob", password="bob_password")
+        result = RM.whoami()
+
+        # {'roles': ['admin', 'expert'],
+        #  'scopes': ['admin:apikeys',
+        #             'admin:metrics',
+        #             'admin:read:principals',
+        #             'read:config',
+        #             'read:console',
+        #             'read:history',
+        #             'read:lock',
+        #             'read:monitor',
+        #             'read:queue',
+        #             'read:resources',
+        #             'read:status',
+        #             'read:testing',
+        #             'user:apikeys',
+        #             'write:config',
+        #             'write:execute',
+        #             'write:history:edit',
+        #             'write:lock',
+        #             'write:manager:control',
+        #             'write:permissions',
+        #             'write:plan:control',
+        #             'write:queue:control',
+        #             'write:queue:edit',
+        #             'write:scripts']}
+
+    Parameters
+    ----------
+    token, api_key: str or None, optional
+        Access token or an API key. The parameters are mutually exclusive: the API fails
+        if both parameters are not *None*. A token or an API key overrides the default
+        authentication key. Default: *None*.
+
+    Returns
+    -------
+    dict
+        Dictionary keys: ``roles``, ``scopes``. See the example in the API description.
+
+    Raises
+    ------
+    RequestParameterError
+        Incorrect or insufficient parameters in the API call.
+    HTTPRequestError, HTTPClientError, HTTPServerError
+        Error while sending and processing HTTP request.
+"""
+
+_doc_api_logout = """
+    Log out. The API sends ``/auth/logout`` API request to the server and then clears
+    local authorization key. Currently the ``/auth/logout`` API is intended for clearing
+    browser cookies and serves no useful purpose for Python scripts and application.
+    ``REManagerAPI.logout()`` is implemented for completeness. The same effect may
+    be achieved by calling ``REManagerAPI.set_authorization_key()``, which does not call
+    ``/auth/logout`` API, but clears the default security key.
+
+    Returns
+    -------
+    dict
+        Empty dictionary: ``{}``.
+
+    Raises
+    ------
+    RequestParameterError
+        Incorrect or insufficient parameters in the API call.
+    HTTPRequestError, HTTPClientError, HTTPServerError
+        Error while sending and processing HTTP request.
+"""
+
+
+_doc_api_session_revoke
+_doc_api_apikey_new
+_doc_api_apikey_info
+_doc_api_apikey_delete
+_doc_api_whoami
+_doc_api_principal_info
+_doc_api_api_scopes
+_doc_api_logout

--- a/bluesky_queueserver_api/comm_async.py
+++ b/bluesky_queueserver_api/comm_async.py
@@ -134,6 +134,37 @@ class ReManagerComm_HTTP_Async(ReManagerAPI_HTTP_Base):
         response = self._process_login_response(response=response)
         return response
 
+    async def session_revoke(self, *, session_uid):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    async def apikey_new(self, *, expires_in, scopes=None, note=None, principal_uid=None):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    async def apikey_info(self, *, api_key=None):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    async def whoami(self, *, token=None, api_key=None):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    async def principal_info(self, *, principal_uid=None):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    async def api_scopes(self, *, token=None, api_key=None):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    async def apikey_delete(self, *, first_eight):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    async def logout(self):
+        raise NotImplementedError()
+
     async def close(self):
         self._is_closing = True
         await self._console_monitor.disable_wait(timeout=self._console_monitor_poll_period * 10)

--- a/bluesky_queueserver_api/comm_async.py
+++ b/bluesky_queueserver_api/comm_async.py
@@ -77,15 +77,19 @@ class ReManagerComm_HTTP_Async(ReManagerAPI_HTTP_Base):
         timeout = self._adjust_timeout(timeout)
         return httpx.AsyncClient(base_url=http_server_uri, timeout=timeout)
 
-    async def _simple_request(self, *, method, params=None, headers=None, data=None, timeout=None):
+    async def _simple_request(
+        self, *, method, params=None, url_params=None, headers=None, data=None, timeout=None
+    ):
         """
         The code that formats and sends a simple request.
         """
         try:
             client_response = None
             request_method, endpoint, payload = self._prepare_request(method=method, params=params)
-            headers = self._prepare_headers()
+            headers = headers or self._prepare_headers()
             kwargs = {"json": payload}
+            if url_params:
+                kwargs.update({"params": url_params})
             if headers:
                 kwargs.update({"headers": headers})
             if data:
@@ -103,11 +107,26 @@ class ReManagerComm_HTTP_Async(ReManagerAPI_HTTP_Base):
         return response
 
     async def send_request(
-        self, *, method, params=None, headers=None, data=None, timeout=None, auto_refresh_session=True
+        self,
+        *,
+        method,
+        params=None,
+        url_params=None,
+        headers=None,
+        data=None,
+        timeout=None,
+        auto_refresh_session=True,
     ):
         # Docstring is maintained separately
         refresh = False
-        request_params = {"method": method, "params": params, "headers": headers, "data": data, "timeout": timeout}
+        request_params = {
+            "method": method,
+            "params": params,
+            "url_params": url_params,
+            "headers": headers,
+            "data": data,
+            "timeout": timeout,
+        }
         try:
             response = await self._simple_request(**request_params)
         except self.HTTPClientError as ex:

--- a/bluesky_queueserver_api/comm_async.py
+++ b/bluesky_queueserver_api/comm_async.py
@@ -3,7 +3,21 @@ import httpx
 from .comm_base import ReManagerAPI_ZMQ_Base, ReManagerAPI_HTTP_Base
 from bluesky_queueserver import ZMQCommSendAsync
 
-from .api_docstrings import _doc_send_request, _doc_close, _doc_api_login, _doc_api_session_refresh
+from .api_docstrings import (
+    _doc_send_request,
+    _doc_close,
+    _doc_api_login,
+    _doc_api_session_refresh,
+    _doc_api_session_revoke,
+    _doc_api_apikey_new,
+    _doc_api_apikey_info,
+    _doc_api_apikey_delete,
+    _doc_api_whoami,
+    _doc_api_principal_info,
+    _doc_api_api_scopes,
+    _doc_api_logout,
+)
+
 from .console_monitor import ConsoleMonitor_ZMQ_Async, ConsoleMonitor_HTTP_Async
 
 
@@ -203,3 +217,11 @@ ReManagerComm_ZMQ_Async.close.__doc__ = _doc_close
 ReManagerComm_HTTP_Async.close.__doc__ = _doc_close
 ReManagerComm_HTTP_Async.login.__doc__ = _doc_api_login
 ReManagerComm_HTTP_Async.session_refresh.__doc__ = _doc_api_session_refresh
+ReManagerComm_HTTP_Async.session_revoke.__doc__ = _doc_api_session_revoke
+ReManagerComm_HTTP_Async.apikey_new.__doc__ = _doc_api_apikey_new
+ReManagerComm_HTTP_Async.apikey_info.__doc__ = _doc_api_apikey_info
+ReManagerComm_HTTP_Async.apikey_delete.__doc__ = _doc_api_apikey_delete
+ReManagerComm_HTTP_Async.whoami.__doc__ = _doc_api_whoami
+ReManagerComm_HTTP_Async.principal_info.__doc__ = _doc_api_principal_info
+ReManagerComm_HTTP_Async.api_scopes.__doc__ = _doc_api_api_scopes
+ReManagerComm_HTTP_Async.logout.__doc__ = _doc_api_logout

--- a/bluesky_queueserver_api/comm_async.py
+++ b/bluesky_queueserver_api/comm_async.py
@@ -134,36 +134,59 @@ class ReManagerComm_HTTP_Async(ReManagerAPI_HTTP_Base):
         response = self._process_login_response(response=response)
         return response
 
-    async def session_revoke(self, *, session_uid):
+    async def session_revoke(self, *, session_uid, token=None, api_key=None):
         # Docstring is maintained separately
-        raise NotImplementedError()
+        method, headers = self._prepare_session_revoke(session_uid=session_uid, token=token, api_key=api_key)
+        kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
+        response = await self.send_request(method=method, **kwargs)
+        return response
 
     async def apikey_new(self, *, expires_in, scopes=None, note=None, principal_uid=None):
         # Docstring is maintained separately
-        raise NotImplementedError()
+        method, request_params = self._prepare_apikey_new(
+            expires_in=expires_in, scopes=scopes, note=note, principal_uid=principal_uid
+        )
+        response = await self.send_request(method=method, params=request_params)
+        return response
 
     async def apikey_info(self, *, api_key=None):
         # Docstring is maintained separately
-        raise NotImplementedError()
+        headers = self._prepare_apikey_info(api_key=api_key)
+        kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
+        response = await self.send_request(method="apikey_info", **kwargs)
+        return response
+
+    async def apikey_delete(self, *, first_eight, token=None, api_key=None):
+        # Docstring is maintained separately
+        url_params, headers = self._prepare_apikey_delete(first_eight=first_eight, token=token, api_key=api_key)
+        kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
+        response = await self.send_request(method="apikey_delete", url_params=url_params, **kwargs)
+        return response
 
     async def whoami(self, *, token=None, api_key=None):
         # Docstring is maintained separately
-        raise NotImplementedError()
+        headers = self._prepare_whoami(token=token, api_key=api_key)
+        kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
+        response = await self.send_request(method="whoami", **kwargs)
+        return response
 
     async def principal_info(self, *, principal_uid=None):
         # Docstring is maintained separately
-        raise NotImplementedError()
+        method = self._prepare_principal_info(principal_uid=principal_uid)
+        response = await self.send_request(method=method)
+        return response
 
     async def api_scopes(self, *, token=None, api_key=None):
         # Docstring is maintained separately
-        raise NotImplementedError()
-
-    async def apikey_delete(self, *, first_eight):
-        # Docstring is maintained separately
-        raise NotImplementedError()
+        headers = self._prepare_whoami(token=token, api_key=api_key)
+        kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
+        response = await self.send_request(method="api_scopes", **kwargs)
+        return response
 
     async def logout(self):
-        raise NotImplementedError()
+        response = await self.send_request(method="logout")
+        self.set_authorization_key()  # Clear authorization keys
+        return response
 
     async def close(self):
         self._is_closing = True

--- a/bluesky_queueserver_api/comm_base.py
+++ b/bluesky_queueserver_api/comm_base.py
@@ -161,9 +161,12 @@ class ReManagerAPI_Base:
         a dictionary and contains no ``"success"``, then it is considered successful.
         """
         if self._request_fail_exceptions:
-            # If the response is mapping, and it has 'success': False, then consider the
-            #   request failed. Let's allow API to return types other than dictionaries.
-            if isinstance(response, Mapping) and not response.get("success", True):
+            # The response must be a list or a dictionary. If the response is a dictionary
+            #   and the key 'success': False, then consider the request failed. If there
+            #   is not 'success' key, then consider the request successful.
+            is_iterable = isinstance(response, Iterable) and not isinstance(response, str)
+            is_mapping = isinstance(response, Mapping)
+            if not any([is_iterable, is_mapping]) or (is_mapping and not response.get("success", True)):
                 raise self.RequestFailedError(request, response)
 
     @property

--- a/bluesky_queueserver_api/comm_threads.py
+++ b/bluesky_queueserver_api/comm_threads.py
@@ -165,13 +165,13 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         sessions for different users without changing the default authorization key (without
         logging out).
 
-        Example
-        -------
+        Examples
+        --------
 
         Log into the server, find UID of a session and revoke the session.
 
             RM.login("bob", password="bob_password")
-            RM.whoami()
+            result = RM.whoami()
 
             # {'uuid': '352cae89-7e94-45be-a405-c39099ebe515',
             #  'type': 'user',
@@ -179,21 +179,21 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
             #     {'id': 'bob',
             #       'provider': 'toy',
             #       'latest_login': '2022-10-02T02:47:57'}],
-            #       'api_keys': [],
-            #       'sessions': [{'uuid': 'e544d4b6-4750-43c3-8ba0-b7e9aedd2045',
-            #                     'expiration_time': '2023-10-01T19:28:15',
-            #                     'revoked': False},
-            #                    {'uuid': '66ee49c1-32b4-4778-8502-205e35151736',
-            #                     'expiration_time': '2023-10-01T19:30:03',
-            #                     'revoked': False},
+            #   'api_keys': [],
+            #   'sessions': [{'uuid': 'e544d4b6-4750-43c3-8ba0-b7e9aedd2045',
+            #                 'expiration_time': '2023-10-01T19:28:15',
+            #                 'revoked': False},
+            #                {'uuid': '66ee49c1-32b4-4778-8502-205e35151736',
+            #                 'expiration_time': '2023-10-01T19:30:03',
+            #                 'revoked': False},
             #       .....................................................
-            #                    {'uuid': 'c41d2f01-607e-49c0-9b3e-a93c383330c0',
-            #                     'expiration_time': '2023-10-02T02:47:57',
-            #                     'revoked': False}],
-            #       'latest_activity': '2022-10-02T02:47:57',
-            #       'roles': [],
-            #       'scopes': [],
-            #       'api_key_scopes': None}
+            #                {'uuid': 'c41d2f01-607e-49c0-9b3e-a93c383330c0',
+            #                 'expiration_time': '2023-10-02T02:47:57',
+            #                 'revoked': False}],
+            #   'latest_activity': '2022-10-02T02:47:57',
+            #   'roles': [],
+            #   'scopes': [],
+            #   'api_key_scopes': None}
 
             # Let's revoke session "e544d4b6-4750-43c3-8ba0-b7e9aedd2045"
             RM.session_revoke(session_uid="e544d4b6-4750-43c3-8ba0-b7e9aedd2045")
@@ -207,21 +207,21 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
             #     {'id': 'bob',
             #       'provider': 'toy',
             #       'latest_login': '2022-10-02T02:47:57'}],
-            #       'api_keys': [],
-            #       'sessions': [{'uuid': 'e544d4b6-4750-43c3-8ba0-b7e9aedd2045',
-            #                     'expiration_time': '2023-10-01T19:28:15',
-            #                     'revoked': True},
-            #                    {'uuid': '66ee49c1-32b4-4778-8502-205e35151736',
-            #                     'expiration_time': '2023-10-01T19:30:03',
-            #                     'revoked': False},
+            #   'api_keys': [],
+            #   'sessions': [{'uuid': 'e544d4b6-4750-43c3-8ba0-b7e9aedd2045',
+            #                 'expiration_time': '2023-10-01T19:28:15',
+            #                 'revoked': True},
+            #                {'uuid': '66ee49c1-32b4-4778-8502-205e35151736',
+            #                 'expiration_time': '2023-10-01T19:30:03',
+            #                 'revoked': False},
             #       .....................................................
-            #                    {'uuid': 'c41d2f01-607e-49c0-9b3e-a93c383330c0',
-            #                     'expiration_time': '2023-10-02T02:47:57',
-            #                     'revoked': False}],
-            #       'latest_activity': '2022-10-02T02:47:57',
-            #       'roles': [],
-            #       'scopes': [],
-            #       'api_key_scopes': None}
+            #                {'uuid': 'c41d2f01-607e-49c0-9b3e-a93c383330c0',
+            #                 'expiration_time': '2023-10-02T02:47:57',
+            #                 'revoked': False}],
+            #   'latest_activity': '2022-10-02T02:47:57',
+            #   'roles': [],
+            #   'scopes': [],
+            #   'api_key_scopes': None}
 
         Parameters
         ----------
@@ -231,7 +231,7 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         token, api_key: str or None, optional
             Access token or an API key. The parameters are mutually exclusive: the API fails
             if both parameters are not *None*. A token or an API key overrides the default
-            security key. Default: *None*.
+            authentication key. Default: *None*.
 
         Returns
         -------
@@ -261,8 +261,8 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         principal UID. Principal UID may be found using ``REManagerAPI.whoami()`` or
         ``REManagerAPI.principal_info()``.
 
-        Example
-        -------
+        Examples
+        --------
         Log into the server and create an API key, which inherits the scopes from principal::
 
             RM.login("bob", password="bob_password")
@@ -343,6 +343,34 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         return response
 
     def apikey_delete(self, *, first_eight, token=None, api_key=None):
+        """
+        Delete an API key for the authorized principal. The API key is identified by
+        first eight characters. For example, an API key ::
+
+          66ccb3ca33ea091ab297331ba2589bdcf7ea9f5f168dbfd90c156652d1cedd9533c1bc59
+
+        is identified as ``66ccb3ca``. The request is authorized using the default
+        security key (set by ``REManagerAPI.set_authorization_key()`` or as a result of
+        login). Alternatively, a different authorization key (an access token or an API key)
+        can be passed as a parameter. This allows to delete API keys for other prinicipals
+        without logging out or changing the default authorization key.
+
+        Parameters
+        ----------
+        first_eight: str
+            First eight characters of the API key.
+        token, api_key: str or None, optional
+            Access token or an API key. The parameters are mutually exclusive: the API fails
+            if both parameters are not *None*. A token or an API key overrides the default
+            authentication key. Default: *None*.
+
+        Raises
+        ------
+        RequestParameterError
+            Incorrect or insufficient parameters in the API call.
+        HTTPRequestError, HTTPClientError, HTTPServerError
+            Error while sending and processing HTTP request.
+        """
         # Docstring is maintained separately
         url_params, headers = self._prepare_apikey_delete(first_eight=first_eight, token=token, api_key=api_key)
         kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
@@ -351,9 +379,54 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
 
     def whoami(self, *, token=None, api_key=None):
         """
-        Returns information about the authorized principal. Works for tokens and API keys.
-        The returned information includes the list of identities, a list of API keys and
-        a list of sessions.
+        Returns full information about the principal. The principal is identified based
+        on the default authorization key (set by ``REManagerAPI.set_authorization_key()``
+        or as a result of login) or the token or the API key passed as parameters.
+        The returned information includes the list of identities, API keys and sessions
+        for the principal.
+
+        Examples
+        --------
+        Log into the server and call ``REManagerAPI.whoami()``::
+
+            RM.login("bob", password="bob_password")
+            result = RM.whoami()
+
+            # {'uuid': '352cae89-7e94-45be-a405-c39099ebe515',
+            #  'type': 'user',
+            #  'identities': [
+            #     {'id': 'bob',
+            #       'provider': 'toy',
+            #       'latest_login': '2022-10-02T02:47:57'}],
+            #   'api_keys': [],
+            #   'sessions': [{'uuid': 'e544d4b6-4750-43c3-8ba0-b7e9aedd2045',
+            #                 'expiration_time': '2023-10-01T19:28:15',
+            #                 'revoked': False},
+            #                {'uuid': '66ee49c1-32b4-4778-8502-205e35151736',
+            #                 'expiration_time': '2023-10-01T19:30:03',
+            #                 'revoked': False},
+            #       .....................................................
+            #                {'uuid': 'c41d2f01-607e-49c0-9b3e-a93c383330c0',
+            #                 'expiration_time': '2023-10-02T02:47:57',
+            #                 'revoked': False}],
+            #   'latest_activity': '2022-10-02T02:47:57',
+            #   'roles': [],
+            #   'scopes': [],
+            #   'api_key_scopes': None}
+
+        Parameters
+        ----------
+        token, api_key: str or None, optional
+            Access token or an API key. The parameters are mutually exclusive: the API fails
+            if both parameters are not *None*. A token or an API key overrides the default
+            authentication key. Default: *None*.
+
+        Raises
+        ------
+        RequestParameterError
+            Incorrect or insufficient parameters in the API call.
+        HTTPRequestError, HTTPClientError, HTTPServerError
+            Error while sending and processing HTTP request.
         """
         # Docstring is maintained separately
         headers = self._prepare_whoami(token=token, api_key=api_key)
@@ -369,7 +442,59 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
 
     def api_scopes(self, *, token=None, api_key=None):
         """
-        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        Returns API scopes for an authorized user. Authorization is performed using
+        the default authorization key (set using ``REManagerAPI.set_authorization_key()``
+        or as a result of login) or an access token or an API key passed as parameters.
+        The API returns the exact list scopes that is currently used by the server for
+        validating access permissions for the token or the API key used for authorization.
+        In addition, the API returns a list of roles for the authorized user.
+        The returned scopes are always a subset of combined scopes of the roles.
+
+        Examples
+        --------
+        Log into the server and get the scopes::
+
+            RM.login("bob", password="bob_password")
+            result = RM.whoami()
+
+            # {'roles': ['admin', 'expert'],
+            #  'scopes': ['admin:apikeys',
+            #             'admin:metrics',
+            #             'admin:read:principals',
+            #             'read:config',
+            #             'read:console',
+            #             'read:history',
+            #             'read:lock',
+            #             'read:monitor',
+            #             'read:queue',
+            #             'read:resources',
+            #             'read:status',
+            #             'read:testing',
+            #             'user:apikeys',
+            #             'write:config',
+            #             'write:execute',
+            #             'write:history:edit',
+            #             'write:lock',
+            #             'write:manager:control',
+            #             'write:permissions',
+            #             'write:plan:control',
+            #             'write:queue:control',
+            #             'write:queue:edit',
+            #             'write:scripts']}
+
+        Parameters
+        ----------
+        token, api_key: str or None, optional
+            Access token or an API key. The parameters are mutually exclusive: the API fails
+            if both parameters are not *None*. A token or an API key overrides the default
+            authentication key. Default: *None*.
+
+        Raises
+        ------
+        RequestParameterError
+            Incorrect or insufficient parameters in the API call.
+        HTTPRequestError, HTTPClientError, HTTPServerError
+            Error while sending and processing HTTP request.
         """
         # Docstring is maintained separately
         headers = self._prepare_whoami(token=token, api_key=api_key)

--- a/bluesky_queueserver_api/comm_threads.py
+++ b/bluesky_queueserver_api/comm_threads.py
@@ -323,6 +323,29 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         obtain information on any API key without logging out or changing
         the default security key.
 
+        Examples
+        --------
+        Log into the server, generate an API key and get the information on the generated
+        API key::
+
+            RM.login("bob", password="bob_password")
+            result_key = RM.apikey_new(expires_in=900)
+
+            # {'first_eight': '48b27a85',
+            #  'expiration_time': '2022-10-02T14:35:59',
+            #  'note': None,
+            #  'scopes': ['inherit'],
+            #  'latest_activity': None,
+            #  'secret': '48b27a85b71946f7840c6d708dd49a42c8945d8cb36b9bb378a3d93d1e1bd586c5851b84'}
+
+            result = RM.apikey_info(api_key=result_key["secret"]
+
+            # {'first_eight': '48b27a85',
+            #  'expiration_time': '2022-10-02T14:35:59',
+            #  'note': None,
+            #  'scopes': ['inherit'],
+            #  'latest_activity': None}
+
         Parameters
         ----------
         api_key: str or None, optional
@@ -363,6 +386,11 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
             Access token or an API key. The parameters are mutually exclusive: the API fails
             if both parameters are not *None*. A token or an API key overrides the default
             authentication key. Default: *None*.
+
+        Returns
+        -------
+        dict
+            Returns the dictionary ``{'success': True, 'msg': ''}`` if success.
 
         Raises
         ------
@@ -421,6 +449,11 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
             if both parameters are not *None*. A token or an API key overrides the default
             authentication key. Default: *None*.
 
+        Returns
+        -------
+        dict
+            Information on the authorized principal. See the example in the API description.
+
         Raises
         ------
         RequestParameterError
@@ -435,6 +468,32 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         return response
 
     def principal_info(self, *, principal_uid=None):
+        """
+        Returns full information on all principals or one principal. The principal
+        information is a dictionary, which is identical to the dictionary returned by
+        ``REManagerAPI.whoami()``. If the ``principal_uid`` is not specified or ``None``,
+        then the list of dictionaries for all principals is returned.
+
+        The client must have administrative privileges to use this API.
+
+        Parameters
+        ----------
+        principal_uid: str or None, optional
+            Principal UID.
+
+        Returns
+        -------
+        dict or list(dict)
+            A dictionary with information on the selected principal or a list of
+            dictionaries with information on all principals.
+
+        Raises
+        ------
+        RequestParameterError
+            Incorrect or insufficient parameters in the API call.
+        HTTPRequestError, HTTPClientError, HTTPServerError
+            Error while sending and processing HTTP request.
+        """
         # Docstring is maintained separately
         method = self._prepare_principal_info(principal_uid=principal_uid)
         response = self.send_request(method=method)
@@ -489,6 +548,11 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
             if both parameters are not *None*. A token or an API key overrides the default
             authentication key. Default: *None*.
 
+        Returns
+        -------
+        dict
+           Dictionary keys: ``roles``, ``scopes``. See the example in the API description.
+
         Raises
         ------
         RequestParameterError
@@ -510,6 +574,18 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         ``REManagerAPI.logout()`` is implemented for completeness. The same effect may
         be achieved by calling ``REManagerAPI.set_authorization_key()``, which does not call
         ``/auth/logout`` API, but clears the default security key.
+
+        Returns
+        -------
+        dict
+            Empty dictionary: ``{}``.
+
+        Raises
+        ------
+        RequestParameterError
+            Incorrect or insufficient parameters in the API call.
+        HTTPRequestError, HTTPClientError, HTTPServerError
+            Error while sending and processing HTTP request.
         """
         # Docstring is maintained separately
         response = self.send_request(method="logout")

--- a/bluesky_queueserver_api/comm_threads.py
+++ b/bluesky_queueserver_api/comm_threads.py
@@ -63,15 +63,17 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         timeout = self._adjust_timeout(timeout)
         return httpx.Client(base_url=http_server_uri, timeout=timeout)
 
-    def _simple_request(self, *, method, params=None, headers=None, data=None, timeout=None):
+    def _simple_request(self, *, method, params=None, url_params=None, headers=None, data=None, timeout=None):
         """
         The code that formats and sends a simple request.
         """
         try:
             client_response = None
-            request_method, endpoint, payload = self._prepare_request(method=method, params=params)
+            request_method, endpoint, params = self._prepare_request(method=method, params=params)
             headers = headers or self._prepare_headers()
-            kwargs = {"json": payload}
+            kwargs = {"json": params}
+            if url_params:
+                kwargs.update({"params": url_params})
             if headers:
                 kwargs.update({"headers": headers})
             if data:
@@ -89,11 +91,26 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         return response
 
     def send_request(
-        self, *, method, params=None, headers=None, data=None, timeout=None, auto_refresh_session=True
+        self,
+        *,
+        method,
+        params=None,
+        url_params=None,
+        headers=None,
+        data=None,
+        timeout=None,
+        auto_refresh_session=True,
     ):
         # Docstring is maintained separately
         refresh = False
-        request_params = {"method": method, "params": params, "headers": headers, "data": data, "timeout": timeout}
+        request_params = {
+            "method": method,
+            "params": params,
+            "url_params": url_params,
+            "headers": headers,
+            "data": data,
+            "timeout": timeout,
+        }
         try:
             response = self._simple_request(**request_params)
         except self.HTTPClientError as ex:
@@ -138,36 +155,87 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         response = self._process_login_response(response=response)
         return response
 
-    def session_revoke(self, *, session_uid):
+    def session_revoke(self, *, session_uid, token=None, api_key=None):
+        """
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        """
         # Docstring is maintained separately
-        raise NotImplementedError()
+        method, headers = self._prepare_session_revoke(session_uid=session_uid, token=token, api_key=api_key)
+        kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
+        response = self.send_request(method=method, **kwargs)
+        return response
 
     def apikey_new(self, *, expires_in, scopes=None, note=None, principal_uid=None):
+        """
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        """
         # Docstring is maintained separately
-        raise NotImplementedError()
+        method, request_params = self._prepare_apikey_new(
+            expires_in=expires_in, scopes=scopes, note=note, principal_uid=principal_uid
+        )
+        response = self.send_request(method=method, params=request_params)
+        return response
 
     def apikey_info(self, *, api_key=None):
+        """
+        Returns information about API key used for authorization. The request fails if
+        authorization is performed using token.
+
+        Parameters
+        ----------
+        api_key: str or None
+            API key of interest if different from the security key set by default.
+            The default API key is used if the value is ``None``.
+        """
         # Docstring is maintained separately
-        raise NotImplementedError()
+        headers = self._prepare_apikey_info(api_key=api_key)
+        kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
+        response = self.send_request(method="apikey_info", **kwargs)
+        return response
+
+    def apikey_delete(self, *, first_eight, token=None, api_key=None):
+        # Docstring is maintained separately
+        url_params, headers = self._prepare_apikey_delete(first_eight=first_eight, token=token, api_key=api_key)
+        kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
+        response = self.send_request(method="apikey_delete", url_params=url_params, **kwargs)
+        return response
 
     def whoami(self, *, token=None, api_key=None):
+        """
+        Returns information about the authorized principal. Works for tokens and API keys.
+        The returned information includes the list of identities, a list of API keys and
+        a list of sessions.
+        """
         # Docstring is maintained separately
-        raise NotImplementedError()
+        headers = self._prepare_whoami(token=token, api_key=api_key)
+        kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
+        response = self.send_request(method="whoami", **kwargs)
+        return response
 
     def principal_info(self, *, principal_uid=None):
         # Docstring is maintained separately
-        raise NotImplementedError()
+        method = self._prepare_principal_info(principal_uid=principal_uid)
+        response = self.send_request(method=method)
+        return response
 
     def api_scopes(self, *, token=None, api_key=None):
+        """
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        """
         # Docstring is maintained separately
-        raise NotImplementedError()
-
-    def apikey_delete(self, *, first_eight):
-        # Docstring is maintained separately
-        raise NotImplementedError()
+        headers = self._prepare_whoami(token=token, api_key=api_key)
+        kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
+        response = self.send_request(method="api_scopes", **kwargs)
+        return response
 
     def logout(self):
-        raise NotImplementedError()
+        """
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        """
+        # Docstring is maintained separately
+        response = self.send_request(method="logout")
+        self.set_authorization_key()  # Clear authorization keys
+        return response
 
     def close(self):
         self._is_closing = True

--- a/bluesky_queueserver_api/comm_threads.py
+++ b/bluesky_queueserver_api/comm_threads.py
@@ -138,6 +138,37 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         response = self._process_login_response(response=response)
         return response
 
+    def session_revoke(self, *, session_uid):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    def apikey_new(self, *, expires_in, scopes=None, note=None, principal_uid=None):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    def apikey_info(self, *, api_key=None):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    def whoami(self, *, token=None, api_key=None):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    def principal_info(self, *, principal_uid=None):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    def api_scopes(self, *, token=None, api_key=None):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    def apikey_delete(self, *, first_eight):
+        # Docstring is maintained separately
+        raise NotImplementedError()
+
+    def logout(self):
+        raise NotImplementedError()
+
     def close(self):
         self._is_closing = True
         self._console_monitor.disable_wait(timeout=self._console_monitor_poll_period * 10)

--- a/bluesky_queueserver_api/comm_threads.py
+++ b/bluesky_queueserver_api/comm_threads.py
@@ -351,7 +351,12 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
 
     def logout(self):
         """
-        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        Log out. The API sends ``/auth/logout`` API request to the server and then clears
+        local authorization key. Currently the ``/auth/logout`` API is intended for clearing
+        browser cookies and serves no useful purpose for Python scripts and application.
+        ``REManagerAPI.logout()`` is implemented for completeness. The same effect may
+        be achieved by calling ``REManagerAPI.set_authorization_key()``, which does not call
+        ``/auth/logout`` API, but clears the default security key.
         """
         # Docstring is maintained separately
         response = self.send_request(method="logout")

--- a/bluesky_queueserver_api/comm_threads.py
+++ b/bluesky_queueserver_api/comm_threads.py
@@ -3,7 +3,21 @@ import httpx
 from .comm_base import ReManagerAPI_ZMQ_Base, ReManagerAPI_HTTP_Base
 from bluesky_queueserver import ZMQCommSendThreads
 
-from .api_docstrings import _doc_send_request, _doc_close, _doc_api_login, _doc_api_session_refresh
+from .api_docstrings import (
+    _doc_send_request,
+    _doc_close,
+    _doc_api_login,
+    _doc_api_session_refresh,
+    _doc_api_session_revoke,
+    _doc_api_apikey_new,
+    _doc_api_apikey_info,
+    _doc_api_apikey_delete,
+    _doc_api_whoami,
+    _doc_api_principal_info,
+    _doc_api_api_scopes,
+    _doc_api_logout,
+)
+
 from .console_monitor import ConsoleMonitor_ZMQ_Threads, ConsoleMonitor_HTTP_Threads
 
 
@@ -156,96 +170,6 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         return response
 
     def session_revoke(self, *, session_uid, token=None, api_key=None):
-        """
-        Revoke session for an authorized user. If the session is revoked, the respective refresh
-        token can no longer be used to refresh session. Access tokens and API keys will continue
-        working. By default the API request is authorized using the default authorization key
-        (set using ``set_authorization_key()`` or as a result of login). A token or an API key
-        passed as a parameter override the default authorization key, which allows to revoke
-        sessions for different users without changing the default authorization key (without
-        logging out).
-
-        Examples
-        --------
-
-        Log into the server, find UID of a session and revoke the session.
-
-            RM.login("bob", password="bob_password")
-            result = RM.whoami()
-
-            # {'uuid': '352cae89-7e94-45be-a405-c39099ebe515',
-            #  'type': 'user',
-            #  'identities': [
-            #     {'id': 'bob',
-            #       'provider': 'toy',
-            #       'latest_login': '2022-10-02T02:47:57'}],
-            #   'api_keys': [],
-            #   'sessions': [{'uuid': 'e544d4b6-4750-43c3-8ba0-b7e9aedd2045',
-            #                 'expiration_time': '2023-10-01T19:28:15',
-            #                 'revoked': False},
-            #                {'uuid': '66ee49c1-32b4-4778-8502-205e35151736',
-            #                 'expiration_time': '2023-10-01T19:30:03',
-            #                 'revoked': False},
-            #       .....................................................
-            #                {'uuid': 'c41d2f01-607e-49c0-9b3e-a93c383330c0',
-            #                 'expiration_time': '2023-10-02T02:47:57',
-            #                 'revoked': False}],
-            #   'latest_activity': '2022-10-02T02:47:57',
-            #   'roles': [],
-            #   'scopes': [],
-            #   'api_key_scopes': None}
-
-            # Let's revoke session "e544d4b6-4750-43c3-8ba0-b7e9aedd2045"
-            RM.session_revoke(session_uid="e544d4b6-4750-43c3-8ba0-b7e9aedd2045")
-
-            result = RM.whoami()
-
-            # NOTE: the session is now labeled as revoked ("revoked": True)
-            # {'uuid': '352cae89-7e94-45be-a405-c39099ebe515',
-            #  'type': 'user',
-            #  'identities': [
-            #     {'id': 'bob',
-            #       'provider': 'toy',
-            #       'latest_login': '2022-10-02T02:47:57'}],
-            #   'api_keys': [],
-            #   'sessions': [{'uuid': 'e544d4b6-4750-43c3-8ba0-b7e9aedd2045',
-            #                 'expiration_time': '2023-10-01T19:28:15',
-            #                 'revoked': True},
-            #                {'uuid': '66ee49c1-32b4-4778-8502-205e35151736',
-            #                 'expiration_time': '2023-10-01T19:30:03',
-            #                 'revoked': False},
-            #       .....................................................
-            #                {'uuid': 'c41d2f01-607e-49c0-9b3e-a93c383330c0',
-            #                 'expiration_time': '2023-10-02T02:47:57',
-            #                 'revoked': False}],
-            #   'latest_activity': '2022-10-02T02:47:57',
-            #   'roles': [],
-            #   'scopes': [],
-            #   'api_key_scopes': None}
-
-        Parameters
-        ----------
-        session_uid: str
-            Full session UID. Session UID may be obtained from results returned by
-            ``REManagerAPI.whoami()`` or ``REManagerAPI.principal_info()``.
-        token, api_key: str or None, optional
-            Access token or an API key. The parameters are mutually exclusive: the API fails
-            if both parameters are not *None*. A token or an API key overrides the default
-            authentication key. Default: *None*.
-
-        Returns
-        -------
-        dict
-            Returns the dictionary ``{'success': True, 'msg': ''}`` if success.
-
-        Raises
-        ------
-        RequestParameterError
-            Incorrect or insufficient parameters in the API call.
-        HTTPRequestError, HTTPClientError, HTTPServerError
-            Error while sending and processing HTTP request.
-
-        """
         # Docstring is maintained separately
         method, headers = self._prepare_session_revoke(session_uid=session_uid, token=token, api_key=api_key)
         kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
@@ -253,58 +177,6 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         return response
 
     def apikey_new(self, *, expires_in, scopes=None, note=None, principal_uid=None):
-        """
-        Generate a new API key for authorized user. The API request is authorized using the
-        default security key (set using ``set_authorization_key()`` or as a result of login).
-
-        Users with administrative privileges can generate API keys for other users based on
-        principal UID. Principal UID may be found using ``REManagerAPI.whoami()`` or
-        ``REManagerAPI.principal_info()``.
-
-        Examples
-        --------
-        Log into the server and create an API key, which inherits the scopes from principal::
-
-            RM.login("bob", password="bob_password")
-            result = RM.apikey_new(expires_in=900)
-
-            # {'first_eight': '66ccb3ca',
-            #  'expiration_time': '2022-10-02T03:29:20',
-            #  'note': None,
-            #  'scopes': ['inherit'],
-            #  'latest_activity': None,
-            #  'secret': '66ccb3ca33ea091ab297331ba2589bdcf7ea9f5f168dbfd90c156652d1cedd9533c1bc59'}
-
-        Parameters
-        ----------
-        expires_in: int
-            Duration of API lifetime in seconds. Lifetime must be positive non-zero integer.
-        scopes: list(str) or None, optional
-            Optional list of scopes, such as ``["read:status", "read:queue", "user:apikeys"]``.
-            If the value is ``None`` (default), then the new API inherits the allowed scopes
-            of the principal (if authorized with token) or the original API key (if authorized
-            with API key). Default: *None*.
-        note: str or None, optional
-            Optional note. Default: *None*.
-        principal_uid: str or None, optional
-            Principal UID of a user. Including principal UID allows to create API keys
-            for any user registered in the database (user who logged into the server at least
-            once). This operation requires administrative privileges. The API fails if
-            ``principal_uid`` is not *None* and authorization is performed with security key
-            that does not have administrative privileges. Default: *None*.
-
-        Returns
-        -------
-        dict
-            The API key is returned as ``'secret'`` key of the dictionary.
-
-        Raises
-        ------
-        RequestParameterError
-            Incorrect or insufficient parameters in the API call.
-        HTTPRequestError, HTTPClientError, HTTPServerError
-            Error while sending and processing HTTP request.
-        """
         # Docstring is maintained separately
         method, request_params = self._prepare_apikey_new(
             expires_in=expires_in, scopes=scopes, note=note, principal_uid=principal_uid
@@ -313,52 +185,6 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         return response
 
     def apikey_info(self, *, api_key=None):
-        """
-        Get information about an API key. The API returning information about the API
-        key used to authorize the request. The request fails if a token is used for
-        authorization. If the parameter ``api_key`` is *None*, then the default
-        security key (set by ``REManagerAPI.set_authorization_key()`` and must be
-        an API key, not a token) is used. The API key passed with the parameter ``api_key``
-        override the default security key (the default is ignored). This allows to
-        obtain information on any API key without logging out or changing
-        the default security key.
-
-        Examples
-        --------
-        Log into the server, generate an API key and get the information on the generated
-        API key::
-
-            RM.login("bob", password="bob_password")
-            result_key = RM.apikey_new(expires_in=900)
-
-            # {'first_eight': '48b27a85',
-            #  'expiration_time': '2022-10-02T14:35:59',
-            #  'note': None,
-            #  'scopes': ['inherit'],
-            #  'latest_activity': None,
-            #  'secret': '48b27a85b71946f7840c6d708dd49a42c8945d8cb36b9bb378a3d93d1e1bd586c5851b84'}
-
-            result = RM.apikey_info(api_key=result_key["secret"]
-
-            # {'first_eight': '48b27a85',
-            #  'expiration_time': '2022-10-02T14:35:59',
-            #  'note': None,
-            #  'scopes': ['inherit'],
-            #  'latest_activity': None}
-
-        Parameters
-        ----------
-        api_key: str or None, optional
-            API key of interest. The parameter is used for authorization of the request
-            instead of the default security key, which is ignored. Default: ``None``.
-
-        Raises
-        ------
-        RequestParameterError
-            Incorrect or insufficient parameters in the API call.
-        HTTPRequestError, HTTPClientError, HTTPServerError
-            Error while sending and processing HTTP request.
-        """
         # Docstring is maintained separately
         headers = self._prepare_apikey_info(api_key=api_key)
         kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
@@ -366,39 +192,6 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         return response
 
     def apikey_delete(self, *, first_eight, token=None, api_key=None):
-        """
-        Delete an API key for the authorized principal. The API key is identified by
-        first eight characters. For example, an API key ::
-
-          66ccb3ca33ea091ab297331ba2589bdcf7ea9f5f168dbfd90c156652d1cedd9533c1bc59
-
-        is identified as ``66ccb3ca``. The request is authorized using the default
-        security key (set by ``REManagerAPI.set_authorization_key()`` or as a result of
-        login). Alternatively, a different authorization key (an access token or an API key)
-        can be passed as a parameter. This allows to delete API keys for other prinicipals
-        without logging out or changing the default authorization key.
-
-        Parameters
-        ----------
-        first_eight: str
-            First eight characters of the API key.
-        token, api_key: str or None, optional
-            Access token or an API key. The parameters are mutually exclusive: the API fails
-            if both parameters are not *None*. A token or an API key overrides the default
-            authentication key. Default: *None*.
-
-        Returns
-        -------
-        dict
-            Returns the dictionary ``{'success': True, 'msg': ''}`` if success.
-
-        Raises
-        ------
-        RequestParameterError
-            Incorrect or insufficient parameters in the API call.
-        HTTPRequestError, HTTPClientError, HTTPServerError
-            Error while sending and processing HTTP request.
-        """
         # Docstring is maintained separately
         url_params, headers = self._prepare_apikey_delete(first_eight=first_eight, token=token, api_key=api_key)
         kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
@@ -406,61 +199,6 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         return response
 
     def whoami(self, *, token=None, api_key=None):
-        """
-        Returns full information about the principal. The principal is identified based
-        on the default authorization key (set by ``REManagerAPI.set_authorization_key()``
-        or as a result of login) or the token or the API key passed as parameters.
-        The returned information includes the list of identities, API keys and sessions
-        for the principal.
-
-        Examples
-        --------
-        Log into the server and call ``REManagerAPI.whoami()``::
-
-            RM.login("bob", password="bob_password")
-            result = RM.whoami()
-
-            # {'uuid': '352cae89-7e94-45be-a405-c39099ebe515',
-            #  'type': 'user',
-            #  'identities': [
-            #     {'id': 'bob',
-            #       'provider': 'toy',
-            #       'latest_login': '2022-10-02T02:47:57'}],
-            #   'api_keys': [],
-            #   'sessions': [{'uuid': 'e544d4b6-4750-43c3-8ba0-b7e9aedd2045',
-            #                 'expiration_time': '2023-10-01T19:28:15',
-            #                 'revoked': False},
-            #                {'uuid': '66ee49c1-32b4-4778-8502-205e35151736',
-            #                 'expiration_time': '2023-10-01T19:30:03',
-            #                 'revoked': False},
-            #       .....................................................
-            #                {'uuid': 'c41d2f01-607e-49c0-9b3e-a93c383330c0',
-            #                 'expiration_time': '2023-10-02T02:47:57',
-            #                 'revoked': False}],
-            #   'latest_activity': '2022-10-02T02:47:57',
-            #   'roles': [],
-            #   'scopes': [],
-            #   'api_key_scopes': None}
-
-        Parameters
-        ----------
-        token, api_key: str or None, optional
-            Access token or an API key. The parameters are mutually exclusive: the API fails
-            if both parameters are not *None*. A token or an API key overrides the default
-            authentication key. Default: *None*.
-
-        Returns
-        -------
-        dict
-            Information on the authorized principal. See the example in the API description.
-
-        Raises
-        ------
-        RequestParameterError
-            Incorrect or insufficient parameters in the API call.
-        HTTPRequestError, HTTPClientError, HTTPServerError
-            Error while sending and processing HTTP request.
-        """
         # Docstring is maintained separately
         headers = self._prepare_whoami(token=token, api_key=api_key)
         kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
@@ -468,98 +206,12 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         return response
 
     def principal_info(self, *, principal_uid=None):
-        """
-        Returns full information on all principals or one principal. The principal
-        information is a dictionary, which is identical to the dictionary returned by
-        ``REManagerAPI.whoami()``. If the ``principal_uid`` is not specified or ``None``,
-        then the list of dictionaries for all principals is returned.
-
-        The client must have administrative privileges to use this API.
-
-        Parameters
-        ----------
-        principal_uid: str or None, optional
-            Principal UID.
-
-        Returns
-        -------
-        dict or list(dict)
-            A dictionary with information on the selected principal or a list of
-            dictionaries with information on all principals.
-
-        Raises
-        ------
-        RequestParameterError
-            Incorrect or insufficient parameters in the API call.
-        HTTPRequestError, HTTPClientError, HTTPServerError
-            Error while sending and processing HTTP request.
-        """
         # Docstring is maintained separately
         method = self._prepare_principal_info(principal_uid=principal_uid)
         response = self.send_request(method=method)
         return response
 
     def api_scopes(self, *, token=None, api_key=None):
-        """
-        Returns API scopes for an authorized user. Authorization is performed using
-        the default authorization key (set using ``REManagerAPI.set_authorization_key()``
-        or as a result of login) or an access token or an API key passed as parameters.
-        The API returns the exact list scopes that is currently used by the server for
-        validating access permissions for the token or the API key used for authorization.
-        In addition, the API returns a list of roles for the authorized user.
-        The returned scopes are always a subset of combined scopes of the roles.
-
-        Examples
-        --------
-        Log into the server and get the scopes::
-
-            RM.login("bob", password="bob_password")
-            result = RM.whoami()
-
-            # {'roles': ['admin', 'expert'],
-            #  'scopes': ['admin:apikeys',
-            #             'admin:metrics',
-            #             'admin:read:principals',
-            #             'read:config',
-            #             'read:console',
-            #             'read:history',
-            #             'read:lock',
-            #             'read:monitor',
-            #             'read:queue',
-            #             'read:resources',
-            #             'read:status',
-            #             'read:testing',
-            #             'user:apikeys',
-            #             'write:config',
-            #             'write:execute',
-            #             'write:history:edit',
-            #             'write:lock',
-            #             'write:manager:control',
-            #             'write:permissions',
-            #             'write:plan:control',
-            #             'write:queue:control',
-            #             'write:queue:edit',
-            #             'write:scripts']}
-
-        Parameters
-        ----------
-        token, api_key: str or None, optional
-            Access token or an API key. The parameters are mutually exclusive: the API fails
-            if both parameters are not *None*. A token or an API key overrides the default
-            authentication key. Default: *None*.
-
-        Returns
-        -------
-        dict
-           Dictionary keys: ``roles``, ``scopes``. See the example in the API description.
-
-        Raises
-        ------
-        RequestParameterError
-            Incorrect or insufficient parameters in the API call.
-        HTTPRequestError, HTTPClientError, HTTPServerError
-            Error while sending and processing HTTP request.
-        """
         # Docstring is maintained separately
         headers = self._prepare_whoami(token=token, api_key=api_key)
         kwargs = {"headers": headers, "auto_refresh_session": False} if headers else {}
@@ -567,26 +219,6 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
         return response
 
     def logout(self):
-        """
-        Log out. The API sends ``/auth/logout`` API request to the server and then clears
-        local authorization key. Currently the ``/auth/logout`` API is intended for clearing
-        browser cookies and serves no useful purpose for Python scripts and application.
-        ``REManagerAPI.logout()`` is implemented for completeness. The same effect may
-        be achieved by calling ``REManagerAPI.set_authorization_key()``, which does not call
-        ``/auth/logout`` API, but clears the default security key.
-
-        Returns
-        -------
-        dict
-            Empty dictionary: ``{}``.
-
-        Raises
-        ------
-        RequestParameterError
-            Incorrect or insufficient parameters in the API call.
-        HTTPRequestError, HTTPClientError, HTTPServerError
-            Error while sending and processing HTTP request.
-        """
         # Docstring is maintained separately
         response = self.send_request(method="logout")
         self.set_authorization_key()  # Clear authorization keys
@@ -607,3 +239,11 @@ ReManagerComm_ZMQ_Threads.close.__doc__ = _doc_close
 ReManagerComm_HTTP_Threads.close.__doc__ = _doc_close
 ReManagerComm_HTTP_Threads.login.__doc__ = _doc_api_login
 ReManagerComm_HTTP_Threads.session_refresh.__doc__ = _doc_api_session_refresh
+ReManagerComm_HTTP_Threads.session_revoke.__doc__ = _doc_api_session_revoke
+ReManagerComm_HTTP_Threads.apikey_new.__doc__ = _doc_api_apikey_new
+ReManagerComm_HTTP_Threads.apikey_info.__doc__ = _doc_api_apikey_info
+ReManagerComm_HTTP_Threads.apikey_delete.__doc__ = _doc_api_apikey_delete
+ReManagerComm_HTTP_Threads.whoami.__doc__ = _doc_api_whoami
+ReManagerComm_HTTP_Threads.principal_info.__doc__ = _doc_api_principal_info
+ReManagerComm_HTTP_Threads.api_scopes.__doc__ = _doc_api_api_scopes
+ReManagerComm_HTTP_Threads.logout.__doc__ = _doc_api_logout

--- a/bluesky_queueserver_api/tests/common.py
+++ b/bluesky_queueserver_api/tests/common.py
@@ -4,7 +4,11 @@ from bluesky_queueserver.manager.tests.common import (  # noqa: F401
     set_qserver_zmq_address,
     set_qserver_zmq_public_key,
 )
-from bluesky_httpserver.tests.conftest import fastapi_server, fastapi_server_fs  # noqa: F401
+from bluesky_httpserver.tests.conftest import (  # noqa: F401
+    fastapi_server,
+    fastapi_server_fs,
+    setup_server_with_config_file,
+)
 from bluesky_httpserver.tests.conftest import API_KEY_FOR_TESTS
 
 # from .common import re_manager, re_manager_pc_copy, re_manager_cmd, db_catalog  # noqa: F401

--- a/bluesky_queueserver_api/tests/test_api_fs.py
+++ b/bluesky_queueserver_api/tests/test_api_fs.py
@@ -293,54 +293,58 @@ def test_send_request_2(fastapi_server_fs, protocol, library):  # noqa: F811
 
 # Configuration file for 'toy' authentication provider. The passwords are explicitly listed.
 config_toy_yml = """
-uvicorn:
-    host: localhost
-    port: 60610
 authentication:
-    providers:
-        - provider: toy
-          authenticator: bluesky_httpserver.authenticators:DictionaryAuthenticator
-          args:
-              users_to_passwords:
-                  alice: alice_password
-                  bob: bob_password
-                  cara: cara_password
+  providers:
+    - provider: toy
+      authenticator: bluesky_httpserver.authenticators:DictionaryAuthenticator
+      args:
+        users_to_passwords:
+          bob: bob_password
+          alice: alice_password
+          tom: tom_password
+          cara: cara_password
 api_access:
-    policy: bluesky_httpserver.authorization:DictionaryAPIAccessControl
-    args:
-        users:
-            bob:
-                roles:
-                    - admin
-                    - expert
+  policy: bluesky_httpserver.authorization:DictionaryAPIAccessControl
+  args:
+    users:
+      bob:
+        roles:
+          - admin
+          - expert
+      alice:
+        roles: advanced
+      tom:
+        roles: user
 """
 
 
 # Configuration file for 'toy' authentication provider. The passwords are explicitly listed.
 config_toy_yml_short_token_expiration = """
-uvicorn:
-    host: localhost
-    port: 60610
 authentication:
-    providers:
-        - provider: toy
-          authenticator: bluesky_httpserver.authenticators:DictionaryAuthenticator
-          args:
-              users_to_passwords:
-                  alice: alice_password
-                  bob: bob_password
-                  cara: cara_password
-    access_token_max_age: 2
-    refresh_token_max_age: 600
-    session_max_age: 1000
+  providers:
+    - provider: toy
+      authenticator: bluesky_httpserver.authenticators:DictionaryAuthenticator
+      args:
+        users_to_passwords:
+          bob: bob_password
+          alice: alice_password
+          tom: tom_password
+          cara: cara_password
+  access_token_max_age: 2
+  refresh_token_max_age: 600
+  session_max_age: 1000
 api_access:
-    policy: bluesky_httpserver.authorization:DictionaryAPIAccessControl
-    args:
-        users:
-            bob:
-                roles:
-                    - admin
-                    - expert
+  policy: bluesky_httpserver.authorization:DictionaryAPIAccessControl
+  args:
+    users:
+      bob:
+        roles:
+          - admin
+          - expert
+      alice:
+        roles: advanced
+      tom:
+        roles: user
 """
 
 

--- a/bluesky_queueserver_api/tests/test_api_fs.py
+++ b/bluesky_queueserver_api/tests/test_api_fs.py
@@ -1131,3 +1131,95 @@ def test_session_apikey_new_2(
             await RM.close()
 
         asyncio.run(testing())
+
+
+# fmt: off
+@pytest.mark.parametrize("pass_as_param", [None, "token", "api_key"])
+@pytest.mark.parametrize("library", ["THREADS", "ASYNC"])
+@pytest.mark.parametrize("protocol", ["HTTP"])
+# fmt: on
+def test_session_apikey_delete_1(
+    tmpdir,
+    monkeypatch,
+    re_manager_cmd,  # noqa: F811
+    fastapi_server_fs,  # noqa: F811
+    protocol,
+    library,
+    pass_as_param,
+):
+    """
+    ``session_revoke`` API (for HTTP requests).
+    """
+    re_manager_cmd()
+    setup_server_with_config_file(config_file_str=config_toy_yml, tmpdir=tmpdir, monkeypatch=monkeypatch)
+    fastapi_server_fs()
+    rm_api_class = _select_re_manager_api(protocol, library)
+
+    if not _is_async(library):
+        RM = instantiate_re_api_class(rm_api_class, http_auth_provider="/toy/token")
+
+        # Log into the server
+        resp = RM.login("bob", password="bob_password")
+        assert "access_token" in resp, pprint.pformat(resp)
+        assert "refresh_token" in resp, pprint.pformat(resp)
+        token = resp["access_token"]
+
+        resp = RM.apikey_new(expires_in=900)
+        assert "secret" in resp, pprint.pformat(resp)
+        api_key = resp["secret"]
+
+        if pass_as_param == "token":
+            params = {"token": token}
+            RM.set_authorization_key()
+        elif pass_as_param == "api_key":
+            params = {"api_key": api_key}
+            RM.set_authorization_key()
+        elif pass_as_param is None:
+            params = {}
+        else:
+            assert False, f"Unexpected option: pass_as_param={pass_as_param!r}"
+
+        resp = RM.apikey_delete(first_eight=api_key[:8], **params)
+        assert resp == {"success": True, "msg": ""}
+
+        # Check that the API does not exist
+        with pytest.raises(RM.HTTPClientError, match="Invalid API key"):
+            RM.apikey_info(api_key=api_key)
+
+        RM.close()
+    else:
+
+        async def testing():
+            RM = instantiate_re_api_class(rm_api_class, http_auth_provider="/toy/token")
+
+            # Log into the server
+            resp = await RM.login("bob", password="bob_password")
+            assert "access_token" in resp, pprint.pformat(resp)
+            assert "refresh_token" in resp, pprint.pformat(resp)
+            token = resp["access_token"]
+
+            resp = await RM.apikey_new(expires_in=900)
+            assert "secret" in resp, pprint.pformat(resp)
+            api_key = resp["secret"]
+
+            if pass_as_param == "token":
+                params = {"token": token}
+                RM.set_authorization_key()
+            elif pass_as_param == "api_key":
+                params = {"api_key": api_key}
+                RM.set_authorization_key()
+            elif pass_as_param is None:
+                params = {}
+            else:
+                assert False, f"Unexpected option: pass_as_param={pass_as_param!r}"
+
+            resp = await RM.apikey_delete(first_eight=api_key[:8], **params)
+            assert resp == {"success": True, "msg": ""}
+
+            # Check that the API does not exist
+            with pytest.raises(RM.HTTPClientError, match="Invalid API key"):
+                await RM.apikey_info(api_key=api_key)
+
+            await RM.close()
+
+        asyncio.run(testing())

--- a/bluesky_queueserver_api/tests/test_api_fs.py
+++ b/bluesky_queueserver_api/tests/test_api_fs.py
@@ -1240,7 +1240,7 @@ def test_session_whoami_1(
     pass_as_param,
 ):
     """
-    ``whoami`` API (for HTTP requests).
+    ``whoami``, ``api_scopes`` API (for HTTP requests).
     """
     re_manager_cmd()
     setup_server_with_config_file(config_file_str=config_toy_yml, tmpdir=tmpdir, monkeypatch=monkeypatch)
@@ -1275,6 +1275,12 @@ def test_session_whoami_1(
         assert len(resp["identities"]) == 1
         assert resp["identities"][0]["id"] == "bob"
 
+        resp = RM.api_scopes(**params)
+        assert "roles" in resp, pprint.pformat(resp)
+        assert "scopes" in resp, pprint.pformat(resp)
+        assert "admin" in resp["roles"]
+        assert "admin:apikeys" in resp["scopes"]
+
         RM.close()
     else:
 
@@ -1305,6 +1311,12 @@ def test_session_whoami_1(
             resp = await RM.whoami(**params)
             assert len(resp["identities"]) == 1
             assert resp["identities"][0]["id"] == "bob"
+
+            resp = await RM.api_scopes(**params)
+            assert "roles" in resp, pprint.pformat(resp)
+            assert "scopes" in resp, pprint.pformat(resp)
+            assert "admin" in resp["roles"]
+            assert "admin:apikeys" in resp["scopes"]
 
             await RM.close()
 

--- a/bluesky_queueserver_api/tests/test_api_fs.py
+++ b/bluesky_queueserver_api/tests/test_api_fs.py
@@ -1,7 +1,6 @@
 import asyncio
 import getpass
 from io import StringIO
-import os
 import pytest
 import time as ttime
 
@@ -15,6 +14,7 @@ from .common import (
     _is_async,
     _select_re_manager_api,
     instantiate_re_api_class,
+    setup_server_with_config_file,
 )
 
 from ..comm_base import RequestParameterError
@@ -344,24 +344,6 @@ api_access:
 """
 
 
-def _setup_server_with_config_file(*, config_file_str, tmpdir, monkeypatch):
-    """
-    Creates config file for the server in ``tmpdir/config/`` directory and
-    sets up the respective environment variable. Sets ``tmpdir`` as a current directory.
-    """
-    config_fln = "config_httpserver.yml"
-    config_dir = os.path.join(tmpdir, "config")
-    config_path = os.path.join(config_dir, config_fln)
-    os.makedirs(config_dir)
-    with open(config_path, "wt") as f:
-        f.writelines(config_file_str)
-
-    monkeypatch.setenv("QSERVER_HTTP_SERVER_CONFIG", config_path)
-    monkeypatch.chdir(tmpdir)
-
-    return config_path
-
-
 # fmt: off
 @pytest.mark.parametrize("default_provider", [True, False])
 @pytest.mark.parametrize("use_kwargs", [True, False])
@@ -382,7 +364,7 @@ def test_login_1(
     ``login`` API (for HTTP requests). Basic functionality.
     """
     re_manager_cmd()
-    _setup_server_with_config_file(config_file_str=config_toy_yml, tmpdir=tmpdir, monkeypatch=monkeypatch)
+    setup_server_with_config_file(config_file_str=config_toy_yml, tmpdir=tmpdir, monkeypatch=monkeypatch)
     fastapi_server_fs()
     rm_api_class = _select_re_manager_api(protocol, library)
 
@@ -462,7 +444,7 @@ def test_login_2(
     ``login`` API (for HTTP requests). Interactive input of username and password.
     """
     re_manager_cmd()
-    _setup_server_with_config_file(config_file_str=config_toy_yml, tmpdir=tmpdir, monkeypatch=monkeypatch)
+    setup_server_with_config_file(config_file_str=config_toy_yml, tmpdir=tmpdir, monkeypatch=monkeypatch)
     monkeypatch.setattr(getpass, "getpass", lambda: "bob_password")
     fastapi_server_fs()
     rm_api_class = _select_re_manager_api(protocol, library)
@@ -523,7 +505,7 @@ def test_login_3_fail(
     ``login`` API (for HTTP requests). Failing cases due to invalid parameters.
     """
     re_manager_cmd()
-    _setup_server_with_config_file(config_file_str=config_toy_yml, tmpdir=tmpdir, monkeypatch=monkeypatch)
+    setup_server_with_config_file(config_file_str=config_toy_yml, tmpdir=tmpdir, monkeypatch=monkeypatch)
     fastapi_server_fs()
     rm_api_class = _select_re_manager_api(protocol, library)
 
@@ -621,7 +603,7 @@ def test_session_refresh_1(
     ``session_refresh`` API (for HTTP requests). Interactive input of username and password.
     """
     re_manager_cmd()
-    _setup_server_with_config_file(config_file_str=config_toy_yml, tmpdir=tmpdir, monkeypatch=monkeypatch)
+    setup_server_with_config_file(config_file_str=config_toy_yml, tmpdir=tmpdir, monkeypatch=monkeypatch)
     monkeypatch.setattr(getpass, "getpass", lambda: "bob_password")
     fastapi_server_fs()
     rm_api_class = _select_re_manager_api(protocol, library)
@@ -753,10 +735,9 @@ def test_session_refresh_3(
     then repeatedly try to load status from the server.
     """
     re_manager_cmd()
-    _setup_server_with_config_file(
+    setup_server_with_config_file(
         config_file_str=config_toy_yml_short_token_expiration, tmpdir=tmpdir, monkeypatch=monkeypatch
     )
-    # _setup_server_with_config_file(config_file_str=config_toy_yml, tmpdir=tmpdir, monkeypatch=monkeypatch)
     monkeypatch.setattr(getpass, "getpass", lambda: "bob_password")
     fastapi_server_fs()
     rm_api_class = _select_re_manager_api(protocol, library)

--- a/bluesky_queueserver_api/tests/test_comm.py
+++ b/bluesky_queueserver_api/tests/test_comm.py
@@ -31,6 +31,8 @@ def test_ReManagerAPI_Base_01():
 @pytest.mark.parametrize("response, success, msg", [
     (None, False, "Request failed: None"),
     (10, False, "Request failed: 10"),
+    ([], True, ""),
+    ([1, 2, 3], True, ""),
     ({}, True, ""),
     ({"success": True}, True, ""),
     ({"success": False}, False, "Request failed: (no error message)"),

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -273,6 +273,14 @@ API for authentication and authorization (HTTP)
     http.REManagerAPI.set_authorization_key
     http.REManagerAPI.login
     http.REManagerAPI.session_refresh
+    http.REManagerAPI.session_revoke
+    http.REManagerAPI.apikey_new
+    http.REManagerAPI.apikey_info
+    http.REManagerAPI.apikey_delete
+    http.REManagerAPI.whoami
+    http.REManagerAPI.principal_info
+    http.REManagerAPI.api_scopes
+    http.REManagerAPI.logout
 
 ASynchronous Communication with HTTP Server
 -------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The PR contains implementation of additional REST API introduced in  https://github.com/bluesky/bluesky-httpserver/pull/23  and refined in https://github.com/bluesky/bluesky-httpserver/pull/39.

The following API were added:

- `REManagerAPI.session_revoke`
- `REManagerAPI.apikey_new`
- `REManagerAPI.apikey_info`
- `REManagerAPI.apikey_delete`
- `REManagerAPI.whoami`
- `REManagerAPI.principal_info`
- `REManagerAPI.api_scopes`
- `REManagerAPI.logout`
 
## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New API for communicating with HTTP Server: `REManagerAPI.session_revoke()`, `REManagerAPI.apikey_new()`, `REManagerAPI.apikey_info()`, `REManagerAPI.apikey_delete()`, `REManagerAPI.whoami()`, `REManagerAPI.principal_info()`, `REManagerAPI.api_scopes()`, `REManagerAPI.logout()`

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The PR contain detailed unit testing for the new API.

<!--
## Screenshots (if appropriate):
-->
