### PR TITLE
New API: 'config_get' and 'queue_autostart'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,4 +26,4 @@ Python API for Bluesky Queue Server
 The project is currently containing a prototype of the API, which can change at any moment.
 
 * Free software: 3-clause BSD license
-* Documentation: (COMING SOON!) https://bluesky.github.io/bluesky-queueserver-api.
+* Documentation: https://bluesky.github.io/bluesky-queueserver-api.

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -433,6 +433,12 @@ class API_Async_Mixin(API_Base):
         request_params = self._prepare_queue_clear(lock_key=lock_key)
         return await self.send_request(method="queue_clear", params=request_params)
 
+    async def queue_autostart(self, enable, *, lock_key=None):
+        # Docstring is maintained separately
+        request_params = self._prepare_queue_autostart(enable=enable, lock_key=lock_key)
+        self._clear_status_timestamp()
+        return await self.send_request(method="queue_autostart", params=request_params)
+
     async def queue_mode_set(self, **kwargs):
         # Docstring is maintained separately
         request_params = self._prepare_queue_mode_set(**kwargs)

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -5,6 +5,7 @@ import time as ttime
 from ._defaults import default_wait_timeout
 from .api_base import API_Base, WaitMonitor
 from .api_docstrings import (
+    _doc_api_config_get,
     _doc_api_devices_allowed,
     _doc_api_devices_existing,
     _doc_api_environment_close,
@@ -33,6 +34,7 @@ from .api_docstrings import (
     _doc_api_ping,
     _doc_api_plans_allowed,
     _doc_api_plans_existing,
+    _doc_api_queue_autostart,
     _doc_api_queue_clear,
     _doc_api_queue_get,
     _doc_api_queue_mode_set,
@@ -728,6 +730,7 @@ class API_Async_Mixin(API_Base):
 
 API_Async_Mixin.status.__doc__ = _doc_api_status
 API_Async_Mixin.ping.__doc__ = _doc_api_ping
+API_Async_Mixin.config_get.__doc__ = _doc_api_config_get
 API_Async_Mixin.wait_for_idle.__doc__ = _doc_api_wait_for_idle
 API_Async_Mixin.wait_for_idle_or_paused.__doc__ = _doc_api_wait_for_idle_or_paused
 API_Async_Mixin.item_add.__doc__ = _doc_api_item_add
@@ -744,6 +747,7 @@ API_Async_Mixin.queue_stop.__doc__ = _doc_api_queue_stop
 API_Async_Mixin.queue_stop_cancel.__doc__ = _doc_api_queue_stop_cancel
 API_Async_Mixin.queue_clear.__doc__ = _doc_api_queue_clear
 API_Async_Mixin.queue_mode_set.__doc__ = _doc_api_queue_mode_set
+API_Async_Mixin.queue_autostart.__doc__ = _doc_api_queue_autostart
 API_Async_Mixin.queue_get.__doc__ = _doc_api_queue_get
 API_Async_Mixin.history_get.__doc__ = _doc_api_history_get
 API_Async_Mixin.history_clear.__doc__ = _doc_api_history_clear

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -286,6 +286,10 @@ class API_Async_Mixin(API_Base):
         # Docstring is maintained separately
         return await self.status(reload=reload)
 
+    async def config_get(self):
+        # Docstring is maintained separately
+        return await self.send_request(method="config_get")
+
     async def wait_for_idle(self, *, timeout=default_wait_timeout, monitor=None):
         # Docstring is maintained separately
 

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -422,6 +422,14 @@ class API_Base:
         self._add_lock_key(request_params, lock_key)
         return request_params
 
+    def _prepare_queue_autostart(self, *, enable, lock_key):
+        """
+        Prepare parameters for ``queue_autostart``.
+        """
+        request_params = {"enable": bool(enable)}
+        self._add_lock_key(request_params, lock_key)
+        return request_params
+
     def _prepare_queue_mode_set(self, **kwargs):
         """
         Prepare parameters for ``queue_mode_set`` operation.

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -1249,6 +1249,10 @@ _doc_api_queue_mode_set = """
         ignored if ``mode`` kwarg is passed.
     loop: boolean
         Turns LOOP mode ON and OFF
+    ignore_failures: boolean
+        Tells the manager to handle failed plans as successful. If the mode is enabled,
+        the manager proceeds to execution of the next plan in the queue even if
+        the previous plan fails. The mode is disabled by default.
     lock_key: str or None (optional)
         The lock key enables access to the API when RE Manager queue is locked.
         If the parameter is not ``None``, the key overrides the current lock key set by

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -398,6 +398,42 @@ _doc_api_ping = """
     failed (e.g. timeout occurred). See documentation for ``status`` API.
 """
 
+_doc_api_config_get = """
+    Returns config info for RE Manager.
+
+    Returns
+    -------
+    response: dict
+
+        Dictionary keys:
+
+        - ``success``: *boolean* - success of the request.
+
+        - ``msg``: *str* - error message in case the request is rejected by RE Manager
+          or operation failed.
+
+        - ``config``: *dict* with the key **'ip_connect_info'** (a dictionary with
+          IP kernel connect info if the kernel is currently running in the IP worker,
+          empty dictionary otherwise).
+
+    Raises
+    ------
+    RequestTimeoutError, RequestFailedError, HTTPRequestError, HTTPClientError, HTTPServerError
+        All exceptions raised by ``send_request`` API.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        # Synchronous code (0MQ and HTTP)
+        config_info = RM.config_get()["config"]["ip_config_info"]
+
+        # Asynchronous code (0MQ and HTTP)
+        config_info = (await RM.config_get())["config"]["ip_config_info"]
+"""
+
+
 _doc_api_wait_for_idle = """
     Wait for RE Manager to return to ``"idle"`` state. The function performs
     periodic polling of RE Manager status and returns when ``manager_state``

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -1232,6 +1232,53 @@ _doc_api_queue_clear = """
         await RM.queue_clear()
 """
 
+_doc_api_queue_autostart = """
+    Enable/disable autostart mode. In autostart mode, the queue execution is
+    automatically started whenever the queue contains items and the manager
+    and the environment are ready to execute plans. Client applications may
+    check if the manager is in autostart mode using queue_autostart_enabled
+    parameter of RE Manager status (see ‘status’ API).
+
+    Parameters
+    ----------
+    enable: boolean
+        Pass *True* to enable the 'autostart' mode and *False* to disable it.
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager queue is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
+
+    Returns
+    -------
+    response: dict
+
+        Dictionary keys:
+
+        - ``success``: *boolean* - success of the request.
+
+        - ``msg``: *str* - error message in case the request is rejected by RE Manager
+          or operation failed.
+
+    Raises
+    ------
+    RequestTimeoutError, RequestFailedError, HTTPRequestError, HTTPClientError, HTTPServerError
+        All exceptions raised by ``send_request`` API.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        # Synchronous code (0MQ, HTTP)
+        RM.queue_autostart(True)
+        RM.queue_autostart(False)
+
+        # Asynchronous code (0MQ, HTTP)
+        await RM.queue_autostart(True)
+        await RM.queue_autostart(False)
+"""
+
 
 _doc_api_queue_mode_set = """
     Set parameters that define the mode of plan queue execution. Only the parameters

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -281,6 +281,10 @@ class API_Threads_Mixin(API_Base):
         # Docstring is maintained separately
         return self.status(reload=reload)
 
+    def config_get(self):
+        # Docstring is maintained separately
+        return self.send_request(method="config_get")
+
     def wait_for_idle(self, *, timeout=default_wait_timeout, monitor=None):
         # Docstring is maintained separately
         def condition(status):

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -5,6 +5,7 @@ import time as ttime
 from ._defaults import default_wait_timeout
 from .api_base import API_Base, WaitMonitor
 from .api_docstrings import (
+    _doc_api_config_get,
     _doc_api_devices_allowed,
     _doc_api_devices_existing,
     _doc_api_environment_close,
@@ -33,6 +34,7 @@ from .api_docstrings import (
     _doc_api_ping,
     _doc_api_plans_allowed,
     _doc_api_plans_existing,
+    _doc_api_queue_autostart,
     _doc_api_queue_clear,
     _doc_api_queue_get,
     _doc_api_queue_mode_set,
@@ -717,6 +719,7 @@ class API_Threads_Mixin(API_Base):
 
 API_Threads_Mixin.status.__doc__ = _doc_api_status
 API_Threads_Mixin.ping.__doc__ = _doc_api_ping
+API_Threads_Mixin.config_get.__doc__ = _doc_api_config_get
 API_Threads_Mixin.wait_for_idle.__doc__ = _doc_api_wait_for_idle
 API_Threads_Mixin.wait_for_idle_or_paused.__doc__ = _doc_api_wait_for_idle_or_paused
 API_Threads_Mixin.item_add.__doc__ = _doc_api_item_add
@@ -733,6 +736,7 @@ API_Threads_Mixin.queue_stop.__doc__ = _doc_api_queue_stop
 API_Threads_Mixin.queue_stop_cancel.__doc__ = _doc_api_queue_stop_cancel
 API_Threads_Mixin.queue_clear.__doc__ = _doc_api_queue_clear
 API_Threads_Mixin.queue_mode_set.__doc__ = _doc_api_queue_mode_set
+API_Threads_Mixin.queue_autostart.__doc__ = _doc_api_queue_autostart
 API_Threads_Mixin.queue_get.__doc__ = _doc_api_queue_get
 API_Threads_Mixin.history_get.__doc__ = _doc_api_history_get
 API_Threads_Mixin.history_clear.__doc__ = _doc_api_history_clear

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -425,6 +425,12 @@ class API_Threads_Mixin(API_Base):
         request_params = self._prepare_queue_clear(lock_key=lock_key)
         return self.send_request(method="queue_clear", params=request_params)
 
+    def queue_autostart(self, enable, *, lock_key=None):
+        # Docstring is maintained separately
+        request_params = self._prepare_queue_autostart(enable=enable, lock_key=lock_key)
+        self._clear_status_timestamp()
+        return self.send_request(method="queue_autostart", params=request_params)
+
     def queue_mode_set(self, **kwargs):
         # Docstring is maintained separately
         request_params = self._prepare_queue_mode_set(**kwargs)

--- a/bluesky_queueserver_api/comm_base.py
+++ b/bluesky_queueserver_api/comm_base.py
@@ -22,6 +22,7 @@ from ._defaults import (
 rest_api_method_map = {
     "ping": ("GET", "/api/ping"),
     "status": ("GET", "/api/status"),
+    "config_get": ("GET", "/api/config/get"),
     "queue_start": ("POST", "/api/queue/start"),
     "queue_stop": ("POST", "/api/queue/stop"),
     "queue_stop_cancel": ("POST", "/api/queue/stop/cancel"),

--- a/bluesky_queueserver_api/comm_base.py
+++ b/bluesky_queueserver_api/comm_base.py
@@ -27,6 +27,7 @@ rest_api_method_map = {
     "queue_stop_cancel": ("POST", "/api/queue/stop/cancel"),
     "queue_get": ("GET", "/api/queue/get"),
     "queue_clear": ("POST", "/api/queue/clear"),
+    "queue_autostart": ("POST", "/api/queue/autostart"),
     "queue_mode_set": ("POST", "/api/queue/mode/set"),
     "queue_item_add": ("POST", "/api/queue/item/add"),
     "queue_item_add_batch": ("POST", "/api/queue/item/add/batch"),

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -1384,6 +1384,45 @@ def test_queue_clear_01(re_manager, fastapi_server, protocol, library):  # noqa:
 @pytest.mark.parametrize("library", ["THREADS", "ASYNC"])
 @pytest.mark.parametrize("protocol", ["ZMQ", "HTTP"])
 # fmt: on
+def test_queue_autostart_01(re_manager, fastapi_server, protocol, library):  # noqa: F811
+    """
+    ``queue_autostart``: basic test
+    """
+    rm_api_class = _select_re_manager_api(protocol, library)
+
+    def check_resp(resp):
+        assert resp["success"] is True
+        assert resp["msg"] == ""
+
+    def check_status(status, autostart):
+        assert status["queue_autostart_enabled"] == autostart
+
+    if not _is_async(library):
+        RM = instantiate_re_api_class(rm_api_class)
+        check_status(RM.status(), False)
+        check_resp(RM.queue_autostart(True))
+        check_status(RM.status(), True)
+        check_resp(RM.queue_autostart(enable=False))
+        check_status(RM.status(), False)
+        RM.close()
+    else:
+
+        async def testing():
+            RM = instantiate_re_api_class(rm_api_class)
+            check_status(await RM.status(), False)
+            check_resp(await RM.queue_autostart(True))
+            check_status(await RM.status(), True)
+            check_resp(await RM.queue_autostart(enable=False))
+            check_status(await RM.status(), False)
+            await RM.close()
+
+        asyncio.run(testing())
+
+
+# fmt: off
+@pytest.mark.parametrize("library", ["THREADS", "ASYNC"])
+@pytest.mark.parametrize("protocol", ["ZMQ", "HTTP"])
+# fmt: on
 def test_queue_mode_set_01(re_manager, fastapi_server, protocol, library):  # noqa: F811
     """
     ``queue_mode_set``: basic test

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -1394,26 +1394,35 @@ def test_queue_mode_set_01(re_manager, fastapi_server, protocol, library):  # no
         assert resp["success"] is True
         assert resp["msg"] == ""
 
-    def check_status(status, loop_mode):
+    def check_status(status, loop_mode, ignore_failures):
         assert status["plan_queue_mode"]["loop"] == loop_mode
+        assert status["plan_queue_mode"]["ignore_failures"] == ignore_failures
 
     if not _is_async(library):
         RM = instantiate_re_api_class(rm_api_class)
-        check_status(RM.status(), False)
+        check_status(RM.status(), False, False)
         check_resp(RM.queue_mode_set(loop=True))
-        check_status(RM.status(), True)
+        check_status(RM.status(), True, False)
         check_resp(RM.queue_mode_set(loop=False))
-        check_status(RM.status(), False)
+        check_status(RM.status(), False, False)
+        check_resp(RM.queue_mode_set(ignore_failures=True))
+        check_status(RM.status(), False, True)
+        check_resp(RM.queue_mode_set(ignore_failures=False))
+        check_status(RM.status(), False, False)
         RM.close()
     else:
 
         async def testing():
             RM = instantiate_re_api_class(rm_api_class)
-            check_status(await RM.status(), False)
+            check_status(await RM.status(), False, False)
             check_resp(await RM.queue_mode_set(loop=True))
-            check_status(await RM.status(), True)
+            check_status(await RM.status(), True, False)
             check_resp(await RM.queue_mode_set(loop=False))
-            check_status(await RM.status(), False)
+            check_status(await RM.status(), False, False)
+            check_resp(await RM.queue_mode_set(ignore_failures=True))
+            check_status(await RM.status(), False, True)
+            check_resp(await RM.queue_mode_set(ignore_failures=False))
+            check_status(await RM.status(), False, False)
             await RM.close()
 
         asyncio.run(testing())
@@ -1433,26 +1442,27 @@ def test_queue_mode_set_02(re_manager, fastapi_server, protocol, library):  # no
         assert resp["success"] is True
         assert resp["msg"] == ""
 
-    def check_status(status, loop_mode):
+    def check_status(status, loop_mode, ignore_failures):
         assert status["plan_queue_mode"]["loop"] == loop_mode
+        assert status["plan_queue_mode"]["ignore_failures"] == ignore_failures
 
     if not _is_async(library):
         RM = instantiate_re_api_class(rm_api_class)
-        check_status(RM.status(), False)
-        check_resp(RM.queue_mode_set(mode={"loop": True}))
-        check_status(RM.status(), True)
+        check_status(RM.status(), False, False)
+        check_resp(RM.queue_mode_set(mode={"loop": True, "ignore_failures": True}))
+        check_status(RM.status(), True, True)
         check_resp(RM.queue_mode_set(mode="default"))
-        check_status(RM.status(), False)
+        check_status(RM.status(), False, False)
         RM.close()
     else:
 
         async def testing():
             RM = instantiate_re_api_class(rm_api_class)
-            check_status(await RM.status(), False)
-            check_resp(await RM.queue_mode_set(mode={"loop": True}))
-            check_status(await RM.status(), True)
+            check_status(await RM.status(), False, False)
+            check_resp(await RM.queue_mode_set(mode={"loop": True, "ignore_failures": True}))
+            check_status(await RM.status(), True, True)
             check_resp(await RM.queue_mode_set(mode="default"))
-            check_status(await RM.status(), False)
+            check_status(await RM.status(), False, False)
             await RM.close()
 
         asyncio.run(testing())

--- a/bluesky_queueserver_api/tests/test_api.py
+++ b/bluesky_queueserver_api/tests/test_api.py
@@ -164,6 +164,43 @@ def test_status_02(re_manager, fastapi_server, protocol, library, reload):  # no
 
 
 # fmt: off
+@pytest.mark.parametrize("library", ["THREADS", "ASYNC"])
+@pytest.mark.parametrize("protocol", ["ZMQ", "HTTP"])
+# fmt: on
+def test_config_get_01(re_manager, fastapi_server, protocol, library):  # noqa: F811
+    """
+    ``config_get``: basic test
+    """
+    rm_api_class = _select_re_manager_api(protocol, library)
+
+    def check_resp(resp):
+        assert resp["success"] is True, pprint.pformat(resp)
+        assert resp["msg"] == "", pprint.pformat(resp)
+        return resp
+
+    if not _is_async(library):
+        RM = instantiate_re_api_class(rm_api_class)
+        resp = check_resp(RM.config_get())
+        assert "config" in resp, pprint.pformat(resp)
+        assert "ip_connect_info" in resp["config"], pprint.pformat(resp)
+        # Kernel does not exist, so connect info is {}
+        assert resp["config"]["ip_connect_info"] == {}
+        RM.close()
+    else:
+
+        async def testing():
+            RM = instantiate_re_api_class(rm_api_class)
+            resp = check_resp(await RM.config_get())
+            assert "config" in resp, pprint.pformat(resp)
+            assert "ip_connect_info" in resp["config"], pprint.pformat(resp)
+            # Kernel does not exist, so connect info is {}
+            assert resp["config"]["ip_connect_info"] == {}
+            await RM.close()
+
+        asyncio.run(testing())
+
+
+# fmt: off
 @pytest.mark.parametrize("destroy", [False, True])
 @pytest.mark.parametrize("library", ["THREADS", "ASYNC"])
 @pytest.mark.parametrize("protocol", ["ZMQ", "HTTP"])

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -92,6 +92,7 @@ API for controlling RE Manager
 
     zmq.REManagerAPI.status
     zmq.REManagerAPI.ping
+    zmq.REManagerAPI.config_get
     zmq.REManagerAPI.wait_for_idle
     zmq.REManagerAPI.wait_for_idle_or_paused
 
@@ -143,6 +144,7 @@ API for management of RE Queue
     zmq.REManagerAPI.queue_stop
     zmq.REManagerAPI.queue_stop_cancel
     zmq.REManagerAPI.queue_mode_set
+    zmq.REManagerAPI.queue_autostart
 
 API for Controlling RE History
 ******************************


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

New API were added to bring the package up-to-date with the Queue Server:

- `config_get` API
- `queue_autostart` API
- option to set `ignore_failures` mode using `queue_mode_set` API.

The PR should be merged with https://github.com/bluesky/bluesky-httpserver/pull/53

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Add new API that already exist in the Queue Server, but not supported by this package.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New API: `config_get` and `queue_autostart`
- `queue_mode_set` API now supports `ignore_failures` mode.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were implemented.

<!--
## Screenshots (if appropriate):
-->
