### PR TITLE
New API: 'environment_update' and 'kernel_interrupt'

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
       fail-fast: false
 
     env:

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -11,6 +11,7 @@ from .api_docstrings import (
     _doc_api_environment_close,
     _doc_api_environment_destroy,
     _doc_api_environment_open,
+    _doc_api_environment_update,
     _doc_api_function_execute,
     _doc_api_history_clear,
     _doc_api_history_get,
@@ -23,6 +24,7 @@ from .api_docstrings import (
     _doc_api_item_remove,
     _doc_api_item_remove_batch,
     _doc_api_item_update,
+    _doc_api_kernel_interrupt,
     _doc_api_lock,
     _doc_api_lock_all,
     _doc_api_lock_environment,
@@ -775,6 +777,7 @@ API_Async_Mixin.permissions_set.__doc__ = _doc_api_permissions_set
 API_Async_Mixin.environment_open.__doc__ = _doc_api_environment_open
 API_Async_Mixin.environment_close.__doc__ = _doc_api_environment_close
 API_Async_Mixin.environment_destroy.__doc__ = _doc_api_environment_destroy
+API_Async_Mixin.environment_update.__doc__ = _doc_api_environment_update
 API_Async_Mixin.script_upload.__doc__ = _doc_api_script_upload
 API_Async_Mixin.function_execute.__doc__ = _doc_api_function_execute
 API_Async_Mixin.task_status.__doc__ = _doc_api_task_status
@@ -786,6 +789,7 @@ API_Async_Mixin.re_resume.__doc__ = _doc_api_re_resume
 API_Async_Mixin.re_stop.__doc__ = _doc_api_re_stop
 API_Async_Mixin.re_abort.__doc__ = _doc_api_re_abort
 API_Async_Mixin.re_halt.__doc__ = _doc_api_re_halt
+API_Async_Mixin.kernel_interrupt.__doc__ = _doc_api_kernel_interrupt
 API_Async_Mixin.lock.__doc__ = _doc_api_lock
 API_Async_Mixin.lock_environment.__doc__ = _doc_api_lock_environment
 API_Async_Mixin.lock_queue.__doc__ = _doc_api_lock_queue

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -294,6 +294,10 @@ class API_Async_Mixin(API_Base):
         # Docstring is maintained separately
         return await self.send_request(method="config_get")
 
+    async def wait_for_condition(self, condition, *, timeout=default_wait_timeout, monitor=None):
+        # Docstring is maintained separately
+        await self._wait_for_condition(condition=condition, timeout=timeout, monitor=monitor)
+
     async def wait_for_idle(self, *, timeout=default_wait_timeout, monitor=None):
         # Docstring is maintained separately
 
@@ -306,6 +310,13 @@ class API_Async_Mixin(API_Base):
         # Docstring is maintained separately
         def condition(status):
             return status["manager_state"] in ("paused", "idle")
+
+        await self._wait_for_condition(condition=condition, timeout=timeout, monitor=monitor)
+
+    async def wait_for_idle_or_running(self, *, timeout=default_wait_timeout, monitor=None):
+        # Docstring is maintained separately
+        def condition(status):
+            return status["manager_state"] in ("executing_queue", "idle")
 
         await self._wait_for_condition(condition=condition, timeout=timeout, monitor=monitor)
 

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -55,9 +55,9 @@ from .api_docstrings import (
     _doc_api_task_status,
     _doc_api_unlock,
     _doc_api_wait_for_completed_task,
+    _doc_api_wait_for_condition,
     _doc_api_wait_for_idle,
     _doc_api_wait_for_idle_or_paused,
-    _doc_api_wait_for_condition,
     _doc_api_wait_for_idle_or_running,
 )
 

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -57,6 +57,8 @@ from .api_docstrings import (
     _doc_api_wait_for_completed_task,
     _doc_api_wait_for_idle,
     _doc_api_wait_for_idle_or_paused,
+    _doc_api_wait_for_condition,
+    _doc_api_wait_for_idle_or_running,
 )
 
 
@@ -758,8 +760,10 @@ class API_Async_Mixin(API_Base):
 API_Async_Mixin.status.__doc__ = _doc_api_status
 API_Async_Mixin.ping.__doc__ = _doc_api_ping
 API_Async_Mixin.config_get.__doc__ = _doc_api_config_get
+API_Async_Mixin.wait_for_condition.__doc__ = _doc_api_wait_for_condition
 API_Async_Mixin.wait_for_idle.__doc__ = _doc_api_wait_for_idle
 API_Async_Mixin.wait_for_idle_or_paused.__doc__ = _doc_api_wait_for_idle_or_paused
+API_Async_Mixin.wait_for_idle_or_running.__doc__ = _doc_api_wait_for_idle_or_running
 API_Async_Mixin.item_add.__doc__ = _doc_api_item_add
 API_Async_Mixin.item_add_batch.__doc__ = _doc_api_item_add_batch
 API_Async_Mixin.item_update.__doc__ = _doc_api_item_update

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -415,12 +415,10 @@ class API_Async_Mixin(API_Base):
         request_params = self._prepare_environment_control(lock_key=lock_key)
         return await self.send_request(method="environment_destroy", params=request_params)
 
-    async def environment_update(self, *, interrupt_task=None, interrupt_plan=None, lock_key=None):
+    async def environment_update(self, *, run_in_background=None, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        request_params = self._prepare_environment_update(
-            interrupt_task=interrupt_task, interrupt_plan=interrupt_plan, lock_key=lock_key
-        )
+        request_params = self._prepare_environment_update(run_in_background=run_in_background, lock_key=lock_key)
         return await self.send_request(method="environment_update", params=request_params)
 
     async def queue_start(self, *, lock_key=None):
@@ -734,6 +732,14 @@ class API_Async_Mixin(API_Base):
         request_params = self._prepare_unlock(lock_key=lock_key)
         self._clear_status_timestamp()
         return await self.send_request(method="unlock", params=request_params)
+
+    async def kernel_interrupt(self, *, interrupt_task=None, interrupt_plan=None, lock_key=None):
+        # Docstring is maintained separately
+        request_params = self._prepare_kernel_interrupt(
+            interrupt_task=interrupt_task, interrupt_plan=interrupt_plan, lock_key=lock_key
+        )
+        self._clear_status_timestamp()
+        return await self.send_request(method="kernel_interrupt", params=request_params)
 
 
 API_Async_Mixin.status.__doc__ = _doc_api_status

--- a/bluesky_queueserver_api/api_async.py
+++ b/bluesky_queueserver_api/api_async.py
@@ -415,6 +415,14 @@ class API_Async_Mixin(API_Base):
         request_params = self._prepare_environment_control(lock_key=lock_key)
         return await self.send_request(method="environment_destroy", params=request_params)
 
+    async def environment_update(self, *, interrupt_task=None, interrupt_plan=None, lock_key=None):
+        # Docstring is maintained separately
+        self._clear_status_timestamp()
+        request_params = self._prepare_environment_update(
+            interrupt_task=interrupt_task, interrupt_plan=interrupt_plan, lock_key=lock_key
+        )
+        return await self.send_request(method="environment_update", params=request_params)
+
     async def queue_start(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -613,16 +613,14 @@ class API_Base:
         self._add_lock_key(request_params, lock_key)
         return request_params
 
-    def _prepare_environment_update(self, *, interrupt_task, interrupt_plan, lock_key):
+    def _prepare_environment_update(self, *, run_in_background, lock_key):
         """
         Prepare parameters for ``environment_update``
         """
         request_params = {}
-        self._add_request_param(request_params, "interrupt_task", interrupt_task)
-        self._add_request_param(request_params, "interrupt_plan", interrupt_plan)
+        self._add_request_param(request_params, "run_in_background", run_in_background)
         self._add_lock_key(request_params, lock_key)
         return request_params
-
 
     def _prepare_script_upload(self, *, script, update_lists, update_re, run_in_background, lock_key):
         """
@@ -784,6 +782,16 @@ class API_Base:
             return {_: task_status[_] for _ in task_uids if task_status[_] in completed_status_vals}
         else:
             return {}
+
+    def _prepare_kernel_interrupt(self, *, interrupt_task, interrupt_plan, lock_key):
+        """
+        Prepare parameters for ``kernel_interrupt``
+        """
+        request_params = {}
+        self._add_request_param(request_params, "interrupt_task", interrupt_task)
+        self._add_request_param(request_params, "interrupt_plan", interrupt_plan)
+        self._add_lock_key(request_params, lock_key)
+        return request_params
 
     def _validate_lock_key(self, lock_key):
         # lock key may be a non-empty string or None

--- a/bluesky_queueserver_api/api_base.py
+++ b/bluesky_queueserver_api/api_base.py
@@ -613,6 +613,17 @@ class API_Base:
         self._add_lock_key(request_params, lock_key)
         return request_params
 
+    def _prepare_environment_update(self, *, interrupt_task, interrupt_plan, lock_key):
+        """
+        Prepare parameters for ``environment_update``
+        """
+        request_params = {}
+        self._add_request_param(request_params, "interrupt_task", interrupt_task)
+        self._add_request_param(request_params, "interrupt_plan", interrupt_plan)
+        self._add_lock_key(request_params, lock_key)
+        return request_params
+
+
     def _prepare_script_upload(self, *, script, update_lists, update_re, run_in_background, lock_key):
         """
         Prepare parameters for ``script_upload``

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -433,6 +433,30 @@ _doc_api_config_get = """
         config_info = (await RM.config_get())["config"]["ip_config_info"]
 """
 
+_doc_api_wait_for_condition = """
+    The function periodically checks RE Manager status and blocks until the ``condition`` 
+    callable returns *True* and can be used to wait for arbitrary conditions based on
+    RE Manager status and/or user-provided data. The function is raises ``WaitTimeoutError`` 
+    if timeout occurs. The timeout can not be infinite, but may be set to 
+    a large value if necessary.
+
+    Parameters
+    ----------
+    condition: callable
+        Condition is a function (any callable), which is waiting for the returned
+        status to satisfy certain fixed set of conditions. For example, the function
+        which waits for the manager status to become idle:
+
+        .. code-block:: python
+
+            def condition(status):
+                return (status["manager_state"] == "idle")
+
+    timeout: float
+        timeout in seconds
+    monitor: WaitMonitor or None
+        Reference to wait monitor
+"""
 
 _doc_api_wait_for_idle = """
     Wait for RE Manager to return to ``"idle"`` state. The function performs
@@ -489,6 +513,14 @@ _doc_api_wait_for_idle = """
 _doc_api_wait_for_idle_or_paused = """
     Wait for RE Manager to switch to ``idle`` or ``paused`` state. See the documentation
     for ``wait_for_idle`` API.
+"""
+
+_doc_api_wait_for_idle_or_running = """
+    Wait for RE Manager to switch to ``idle`` or ``executing_queue`` state. The API
+    may be useful when working with the queue in AUTOSTART mode. For example, if AUTOSTART 
+    mode is enabled and then the environment is opened, the manager is switched to ``idle``
+    mode if the queue is empty or ``executing_queue`` mode if the queue contains plans.  
+    See the documentation for ``wait_for_idle`` API.
 """
 
 _doc_api_item_add = """

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -434,10 +434,10 @@ _doc_api_config_get = """
 """
 
 _doc_api_wait_for_condition = """
-    The function periodically checks RE Manager status and blocks until the ``condition`` 
+    The function periodically checks RE Manager status and blocks until the ``condition``
     callable returns *True* and can be used to wait for arbitrary conditions based on
-    RE Manager status and/or user-provided data. The function is raises ``WaitTimeoutError`` 
-    if timeout occurs. The timeout can not be infinite, but may be set to 
+    RE Manager status and/or user-provided data. The function is raises ``WaitTimeoutError``
+    if timeout occurs. The timeout can not be infinite, but may be set to
     a large value if necessary.
 
     Parameters
@@ -517,9 +517,9 @@ _doc_api_wait_for_idle_or_paused = """
 
 _doc_api_wait_for_idle_or_running = """
     Wait for RE Manager to switch to ``idle`` or ``executing_queue`` state. The API
-    may be useful when working with the queue in AUTOSTART mode. For example, if AUTOSTART 
+    may be useful when working with the queue in AUTOSTART mode. For example, if AUTOSTART
     mode is enabled and then the environment is opened, the manager is switched to ``idle``
-    mode if the queue is empty or ``executing_queue`` mode if the queue contains plans.  
+    mode if the queue is empty or ``executing_queue`` mode if the queue contains plans.
     See the documentation for ``wait_for_idle`` API.
 """
 

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -1982,6 +1982,63 @@ _doc_api_environment_destroy = """
         await RM.environment_destroy()
 """
 
+
+_doc_api_environment_update = """
+
+    Update RE Worker environment cache. Updates the state and cached parameters of 
+    the worker environment based on contents of the worker namespace. The updated 
+    parameters include the reference to the Run Engine and lists of existing and 
+    available plans and devices. The API is intended for using in cases when 
+    users bypass RE Manager to modify contents of the namespace, for example 
+    by connecting directly to IPython kernel (IPython mode) and executing 
+    commands via Jupyter Console. Use returned ``task_uid`` to monitor execution of 
+    the update task and check the update results.
+
+    Parameters
+    ----------
+
+    run_in_background: boolean (optional, default False)
+        Set this parameter *True* to execute the update in the background thread (while a plan or 
+        another foreground task is running). Generally, it is recommended to run the update 
+        in the main thread. **Developers of data acquisition workflows and/or user specific code 
+        are responsible for thread safety.**    
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
+
+    Returns
+    -------
+    response: dict
+
+        Dictionary keys:
+
+        - ``success``: *boolean* - success of the request.
+
+        - ``msg``: *str* - error message in case the request is rejected by RE Manager
+          or operation failed.
+
+        - ``task_uid``: UID of the task that runs the update.
+
+    Raises
+    ------
+    RequestTimeoutError, RequestFailedError, HTTPRequestError, HTTPClientError, HTTPServerError
+        All exceptions raised by ``send_request`` API.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        # Synchronous code (0MQ, HTTP)
+        RM.environment_update()
+
+        # Asynchronous code (0MQ, HTTP)
+        await RM.environment_update()
+"""
+
+
 _doc_api_script_upload = r"""
     Upload and execute script in RE Worker namespace. The script may add, modify or
     replace objects defined in the namespace, including plans and devices. Dynamic
@@ -2597,6 +2654,60 @@ _doc_api_re_halt = """
         All exceptions raised by ``send_request`` API.
 """
 
+_doc_api_kernel_interrupt = """
+
+    Send interrupt request (Ctrl-C) to the running IPython kernel. The API call fails if
+    IPython mode is not enabled or environment does not exist (there is no IPython kernel).
+    The API is primarily intended to interrupt tasks started by clients connected directly
+    to IPython kernel (such as Jupyter Console) and by default it fails if the manager is
+    executing a plan or a task. Set the ``interrupt_task`` and/or ``interrupt_plan``
+    parameters *True* in order to be able to interrupt a running foreground task or a plan
+    (single interrupt initiates deferred pause, two consecutive interrupts initiate immediate
+    pause). Note, that ``re_pause`` API is more reliable method of pausing the plan. 
+
+    Parameters
+    ----------
+
+    interrupt_task: boolean (optional, default False)
+        Allow the API request to interrupt a task started by RE Manager.
+    interrupt_plan: boolean (optional, default False)
+        Allow the API request to interrupt a running plan (started by RE Manager or directly via
+        Jupyter Console).
+    lock_key: str or None (optional)
+        The lock key enables access to the API when RE Manager environment is locked.
+        If the parameter is not ``None``, the key overrides the current lock key set by
+        ``REManagerAPI.lock_key``. See documentation on ``REMangerAPI.lock()`` for
+        more information. Default: ``None``.
+
+    Returns
+    -------
+    response: dict
+
+        Dictionary keys:
+
+        - ``success``: *boolean* - success of the request.
+
+        - ``msg``: *str* - error message in case the request is rejected by RE Manager
+          or operation failed.
+
+    Raises
+    ------
+    RequestTimeoutError, RequestFailedError, HTTPRequestError, HTTPClientError, HTTPServerError
+        All exceptions raised by ``send_request`` API.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        # Synchronous code (0MQ, HTTP)
+        RM.kernel_interrupt()
+
+        # Asynchronous code (0MQ, HTTP)
+        await RM.kernel_interrupt()
+"""
+
+
 _doc_api_lock = """
     Lock RE Manager with a lock key. The lock may prevent other users (or clients) from modifying
     the environment, starting plans or tasks or editing the queue. The API is intented to
@@ -2633,6 +2744,7 @@ _doc_api_lock = """
     - REManagerAPI.environment_open()
     - REManagerAPI.environment_close()
     - REManagerAPI.environment_destroy()
+    - REManagerAPI.environment_update()
     - REManagerAPI.queue_start()
     - REManagerAPI.queue_stop()
     - REManagerAPI.queue_stop_cancel()
@@ -2642,6 +2754,7 @@ _doc_api_lock = """
     - REManagerAPI.re_stop()
     - REManagerAPI.re_abort()
     - REManagerAPI.re_halt()
+    - REManagerAPI.kernel_interrupt()
     - REManagerAPI.script_upload()
     - REManagerAPI.function_execute()
 
@@ -2649,6 +2762,7 @@ _doc_api_lock = """
     affects the following API:
 
     - REManagerAPI.queue_mode_set()
+    - REManagerAPI.queue_autostart()
     - REManagerAPI.item_add()
     - REManagerAPI.item_add_batch()
     - REManagerAPI.item_update()

--- a/bluesky_queueserver_api/api_docstrings.py
+++ b/bluesky_queueserver_api/api_docstrings.py
@@ -1985,23 +1985,23 @@ _doc_api_environment_destroy = """
 
 _doc_api_environment_update = """
 
-    Update RE Worker environment cache. Updates the state and cached parameters of 
-    the worker environment based on contents of the worker namespace. The updated 
-    parameters include the reference to the Run Engine and lists of existing and 
-    available plans and devices. The API is intended for using in cases when 
-    users bypass RE Manager to modify contents of the namespace, for example 
-    by connecting directly to IPython kernel (IPython mode) and executing 
-    commands via Jupyter Console. Use returned ``task_uid`` to monitor execution of 
+    Update RE Worker environment cache. Updates the state and cached parameters of
+    the worker environment based on contents of the worker namespace. The updated
+    parameters include the reference to the Run Engine and lists of existing and
+    available plans and devices. The API is intended for using in cases when
+    users bypass RE Manager to modify contents of the namespace, for example
+    by connecting directly to IPython kernel (IPython mode) and executing
+    commands via Jupyter Console. Use returned ``task_uid`` to monitor execution of
     the update task and check the update results.
 
     Parameters
     ----------
 
     run_in_background: boolean (optional, default False)
-        Set this parameter *True* to execute the update in the background thread (while a plan or 
-        another foreground task is running). Generally, it is recommended to run the update 
-        in the main thread. **Developers of data acquisition workflows and/or user specific code 
-        are responsible for thread safety.**    
+        Set this parameter *True* to execute the update in the background thread (while a plan or
+        another foreground task is running). Generally, it is recommended to run the update
+        in the main thread. **Developers of data acquisition workflows and/or user specific code
+        are responsible for thread safety.**
     lock_key: str or None (optional)
         The lock key enables access to the API when RE Manager environment is locked.
         If the parameter is not ``None``, the key overrides the current lock key set by
@@ -2663,7 +2663,7 @@ _doc_api_kernel_interrupt = """
     executing a plan or a task. Set the ``interrupt_task`` and/or ``interrupt_plan``
     parameters *True* in order to be able to interrupt a running foreground task or a plan
     (single interrupt initiates deferred pause, two consecutive interrupts initiate immediate
-    pause). Note, that ``re_pause`` API is more reliable method of pausing the plan. 
+    pause). Note, that ``re_pause`` API is more reliable method of pausing the plan.
 
     Parameters
     ----------

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -57,6 +57,8 @@ from .api_docstrings import (
     _doc_api_wait_for_completed_task,
     _doc_api_wait_for_idle,
     _doc_api_wait_for_idle_or_paused,
+    _doc_api_wait_for_condition,
+    _doc_api_wait_for_idle_or_running,
 )
 
 
@@ -747,8 +749,10 @@ class API_Threads_Mixin(API_Base):
 API_Threads_Mixin.status.__doc__ = _doc_api_status
 API_Threads_Mixin.ping.__doc__ = _doc_api_ping
 API_Threads_Mixin.config_get.__doc__ = _doc_api_config_get
+API_Threads_Mixin.wait_for_condition.__doc__ = _doc_api_wait_for_condition
 API_Threads_Mixin.wait_for_idle.__doc__ = _doc_api_wait_for_idle
 API_Threads_Mixin.wait_for_idle_or_paused.__doc__ = _doc_api_wait_for_idle_or_paused
+API_Threads_Mixin.wait_for_idle_or_running.__doc__ = _doc_api_wait_for_idle_or_running
 API_Threads_Mixin.item_add.__doc__ = _doc_api_item_add
 API_Threads_Mixin.item_add_batch.__doc__ = _doc_api_item_add_batch
 API_Threads_Mixin.item_update.__doc__ = _doc_api_item_update

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -407,6 +407,14 @@ class API_Threads_Mixin(API_Base):
         request_params = self._prepare_environment_control(lock_key=lock_key)
         return self.send_request(method="environment_destroy", params=request_params)
 
+    def environment_update(self, *, interrupt_task=None, interrupt_plan=None, lock_key=None):
+        # Docstring is maintained separately
+        self._clear_status_timestamp()
+        request_params = self._prepare_environment_update(
+            interrupt_task=interrupt_task, interrupt_plan=interrupt_plan, lock_key=lock_key
+        )
+        return self.send_request(method="environment_update", params=request_params)
+
     def queue_start(self, *, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -55,9 +55,9 @@ from .api_docstrings import (
     _doc_api_task_status,
     _doc_api_unlock,
     _doc_api_wait_for_completed_task,
+    _doc_api_wait_for_condition,
     _doc_api_wait_for_idle,
     _doc_api_wait_for_idle_or_paused,
-    _doc_api_wait_for_condition,
     _doc_api_wait_for_idle_or_running,
 )
 

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -289,6 +289,10 @@ class API_Threads_Mixin(API_Base):
         # Docstring is maintained separately
         return self.send_request(method="config_get")
 
+    def wait_for_condition(self, condition, *, timeout=default_wait_timeout, monitor=None):
+        # Docstring is maintained separately
+        self._wait_for_condition(condition=condition, timeout=timeout, monitor=monitor)
+
     def wait_for_idle(self, *, timeout=default_wait_timeout, monitor=None):
         # Docstring is maintained separately
         def condition(status):
@@ -300,6 +304,13 @@ class API_Threads_Mixin(API_Base):
         # Docstring is maintained separately
         def condition(status):
             return status["manager_state"] in ("paused", "idle")
+
+        self._wait_for_condition(condition=condition, timeout=timeout, monitor=monitor)
+
+    def wait_for_idle_or_running(self, *, timeout=default_wait_timeout, monitor=None):
+        # Docstring is maintained separately
+        def condition(status):
+            return status["manager_state"] in ("executing_queue", "idle")
 
         self._wait_for_condition(condition=condition, timeout=timeout, monitor=monitor)
 

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -11,6 +11,7 @@ from .api_docstrings import (
     _doc_api_environment_close,
     _doc_api_environment_destroy,
     _doc_api_environment_open,
+    _doc_api_environment_update,
     _doc_api_function_execute,
     _doc_api_history_clear,
     _doc_api_history_get,
@@ -23,6 +24,7 @@ from .api_docstrings import (
     _doc_api_item_remove,
     _doc_api_item_remove_batch,
     _doc_api_item_update,
+    _doc_api_kernel_interrupt,
     _doc_api_lock,
     _doc_api_lock_all,
     _doc_api_lock_environment,
@@ -764,6 +766,7 @@ API_Threads_Mixin.permissions_set.__doc__ = _doc_api_permissions_set
 API_Threads_Mixin.environment_open.__doc__ = _doc_api_environment_open
 API_Threads_Mixin.environment_close.__doc__ = _doc_api_environment_close
 API_Threads_Mixin.environment_destroy.__doc__ = _doc_api_environment_destroy
+API_Threads_Mixin.environment_update.__doc__ = _doc_api_environment_update
 API_Threads_Mixin.script_upload.__doc__ = _doc_api_script_upload
 API_Threads_Mixin.function_execute.__doc__ = _doc_api_function_execute
 API_Threads_Mixin.task_status.__doc__ = _doc_api_task_status
@@ -775,6 +778,7 @@ API_Threads_Mixin.re_resume.__doc__ = _doc_api_re_resume
 API_Threads_Mixin.re_stop.__doc__ = _doc_api_re_stop
 API_Threads_Mixin.re_abort.__doc__ = _doc_api_re_abort
 API_Threads_Mixin.re_halt.__doc__ = _doc_api_re_halt
+API_Threads_Mixin.kernel_interrupt.__doc__ = _doc_api_kernel_interrupt
 API_Threads_Mixin.lock.__doc__ = _doc_api_lock
 API_Threads_Mixin.lock_environment.__doc__ = _doc_api_lock_environment
 API_Threads_Mixin.lock_queue.__doc__ = _doc_api_lock_queue

--- a/bluesky_queueserver_api/api_threads.py
+++ b/bluesky_queueserver_api/api_threads.py
@@ -407,12 +407,10 @@ class API_Threads_Mixin(API_Base):
         request_params = self._prepare_environment_control(lock_key=lock_key)
         return self.send_request(method="environment_destroy", params=request_params)
 
-    def environment_update(self, *, interrupt_task=None, interrupt_plan=None, lock_key=None):
+    def environment_update(self, *, run_in_background=None, lock_key=None):
         # Docstring is maintained separately
         self._clear_status_timestamp()
-        request_params = self._prepare_environment_update(
-            interrupt_task=interrupt_task, interrupt_plan=interrupt_plan, lock_key=lock_key
-        )
+        request_params = self._prepare_environment_update(run_in_background=run_in_background, lock_key=lock_key)
         return self.send_request(method="environment_update", params=request_params)
 
     def queue_start(self, *, lock_key=None):
@@ -719,6 +717,14 @@ class API_Threads_Mixin(API_Base):
         request_params = self._prepare_unlock(lock_key=lock_key)
         self._clear_status_timestamp()
         return self.send_request(method="unlock", params=request_params)
+
+    def kernel_interrupt(self, *, interrupt_task=None, interrupt_plan=None, lock_key=None):
+        # Docstring is maintained separately
+        request_params = self._prepare_kernel_interrupt(
+            interrupt_task=interrupt_task, interrupt_plan=interrupt_plan, lock_key=lock_key
+        )
+        self._clear_status_timestamp()
+        return self.send_request(method="kernel_interrupt", params=request_params)
 
     # =======================================================================================
     #                            Console monitor

--- a/bluesky_queueserver_api/comm_base.py
+++ b/bluesky_queueserver_api/comm_base.py
@@ -44,6 +44,7 @@ rest_api_method_map = {
     "environment_open": ("POST", "/api/environment/open"),
     "environment_close": ("POST", "/api/environment/close"),
     "environment_destroy": ("POST", "/api/environment/destroy"),
+    "environment_update": ("POST", "/api/environment/update"),
     "re_pause": ("POST", "/api/re/pause"),
     "re_resume": ("POST", "/api/re/resume"),
     "re_stop": ("POST", "/api/re/stop"),
@@ -64,6 +65,7 @@ rest_api_method_map = {
     "lock": ("POST", "/api/lock"),
     "unlock": ("POST", "/api/unlock"),
     "lock_info": ("GET", "/api/lock/info"),
+    "kernel_interrupt": ("POST", "/api/kernel/interrupt"),
     "manager_stop": ("POST", "/api/manager/stop"),
     "manager_kill": ("POST", "/api/test/manager/kill"),
     # API available only in HTTP version

--- a/bluesky_queueserver_api/tests/common.py
+++ b/bluesky_queueserver_api/tests/common.py
@@ -5,6 +5,7 @@ from bluesky_httpserver.tests.conftest import (  # noqa: F401
     setup_server_with_config_file,
 )
 from bluesky_queueserver.manager.tests.common import (  # noqa: F401
+    ip_kernel_simple_client,
     re_manager,
     re_manager_cmd,
     set_qserver_zmq_address,

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -106,6 +106,7 @@ API for controlling RE Environment
     zmq.REManagerAPI.environment_open
     zmq.REManagerAPI.environment_close
     zmq.REManagerAPI.environment_destroy
+    zmq.REManagerAPI.environment_update
 
 API for Monitoring Available Resources
 **************************************
@@ -202,6 +203,15 @@ API for controlling Run Engine
     zmq.REManagerAPI.re_stop
     zmq.REManagerAPI.re_abort
     zmq.REManagerAPI.re_halt
+
+API for controlling IPython kernel
+**********************************
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated
+
+    zmq.REManagerAPI.kernel_interrupt
 
 API for monitoring console output of RE manager
 ***********************************************

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -95,6 +95,8 @@ API for controlling RE Manager
     zmq.REManagerAPI.config_get
     zmq.REManagerAPI.wait_for_idle
     zmq.REManagerAPI.wait_for_idle_or_paused
+    zmq.REManagerAPI.wait_for_idle_or_running
+    zmq.REManagerAPI.wait_for_condition
 
 API for controlling RE Environment
 **********************************


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add new API implemented in https://github.com/bluesky/bluesky-queueserver/pull/278


## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New API: `REManagerAPI.environment_update()` and `REManagerAPI.kernel_interrupt()`.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
